### PR TITLE
Query.all and Scan.all Delay Seconds to Milliseconds

### DIFF
--- a/docs/_docs/query.md
+++ b/docs/_docs/query.md
@@ -29,7 +29,7 @@ Executes the query against the table or index.
 
 Recursively query as long as lastKey exists. This function will also return a property called `timesScanned` indicating how many queries were completed.
 
-`delay` is the time (in seconds) between recursive queries. Default: 1sec
+`delay` is the time (in miliseconds) between recursive queries. Default: 1000ms (1sec)
 
 `max` is the maximum number of recursive queries. Default: 0 - unlimited
 

--- a/docs/_docs/scan.md
+++ b/docs/_docs/scan.md
@@ -63,7 +63,7 @@ Executes a scan against a table
 
 Recursively scan as long as lastKey exists. This function will also return a property called `timesScanned` indicating how many scans were completed.
 
-`delay` is the time (in seconds) between recursive scans. Default: 1sec
+`delay` is the time (in miliseconds) between recursive scans. Default: 1000ms (1sec)
 
 `max` is the maximum number of recursive scans. Default: 0 - unlimited
 

--- a/lib/Query.js
+++ b/lib/Query.js
@@ -274,7 +274,7 @@ Query.prototype.exec = function (next) {
           if ((options.all.max === 0 || timesScanned < options.all.max) && lastKey) {
             // query.all need to query again
             queryReq.ExclusiveStartKey = lastKey;
-            setTimeout(queryOne, options.all.delay * 1000);
+            setTimeout(queryOne, options.all.delay);
           } else {
             models.lastKey = lastKey;
             models.count = totalCount;
@@ -544,7 +544,7 @@ Query.prototype.using = function (indexName) {
 };
 
 Query.prototype.all = function (delay, max) {
-  delay = delay || 1;
+  delay = delay || 1000;
   max = max || 0;
   this.options.all = {'delay': delay, 'max': max};
   return this;

--- a/lib/Scan.js
+++ b/lib/Scan.js
@@ -228,7 +228,7 @@ Scan.prototype.exec = function (next) {
           if ((options.all.max === 0 || timesScanned < options.all.max) && lastKey) {
             // scan.all need to scan again
             scanOneReq.ExclusiveStartKey = lastKey;
-            setTimeout(scanOne, options.all.delay * 1000);
+            setTimeout(scanOne, options.all.delay);
           }
           else {
             // completed scan returning models
@@ -550,7 +550,7 @@ Scan.prototype.counts = function () {
 };
 
 Scan.prototype.all = function (delay, max) {
-  delay = delay || 1;
+  delay = delay || 1000;
   max = max || 0;
   this.options.all = {'delay': delay, 'max': max};
   return this;

--- a/test/Query.js
+++ b/test/Query.js
@@ -367,7 +367,7 @@ describe('Query', function (){
   it('Query.all(1, 3)', function (done) {
     var Dog = dynamoose.model('Dog');
 
-    Dog.query('ownerId').eq(20).limit(1).all(1, 3).exec()
+    Dog.query('ownerId').eq(20).limit(1).all(1000, 3).exec()
     .then(function (dogs) {
       dogs.length.should.eql(3);
       dogs.timesScanned.should.eql(3);

--- a/test/Scan.js
+++ b/test/Scan.js
@@ -678,7 +678,7 @@ describe('Scan', function (){
   it('Scan.all(1,2)', function (done) {
     var Dog = dynamoose.model('Dog');
 
-    Dog.scan().all(1,2).limit(5).exec(function (err, dogs) {
+    Dog.scan().all(1000,2).limit(5).exec(function (err, dogs) {
       should.not.exist(err);
       dogs.length.should.eql(10);
       done();


### PR DESCRIPTION
### BREAKING CHANGE

This PR changes the `Query.all` and `Scan.all` functions to accept milliseconds instead of seconds as the delay parameter.

Due to this being a breaking change probably best to hold off till v0.9.0 or v1.0.0.

I would love to hear thoughts on this. I believe this is a good change, but would love to hear the community's opinion on this.