### PR TITLE
Allow attributes to be objects with a `type` prop when using saveUnknown

### DIFF
--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -5,11 +5,11 @@ var util = require('util');
 
 var errors = require('./errors');
 
-function Attribute(schema, name, value) {
+function Attribute(schema, name, value, ignoreType) {
   this.options = {};
 
   debug('Creating attribute %s %o', name, value);
-  if (value.type){
+  if (value.type && !ignoreType){
     this.options = value;
   }
 
@@ -17,7 +17,7 @@ function Attribute(schema, name, value) {
 
   this.name = name;
   if (this.schema.options.saveUnknown) {
-    this.setTypeFromRawValue(value);
+    this.setTypeFromRawValue(value, ignoreType);
   } else {
     this.setType(value);
   }
@@ -43,7 +43,7 @@ function Attribute(schema, name, value) {
 
   if (this.type.name === 'map'){
 
-    if(value.type) {
+    if(value.type && !ignoreType) {
       value = value.map;
     }
     for (var subattrName in value){
@@ -148,7 +148,7 @@ Attribute.prototype.types = {
   }
 };
 
-Attribute.prototype.setTypeFromRawValue = function(value) {
+Attribute.prototype.setTypeFromRawValue = function(value, ignoreType) {
   //no type defined - assume this is not a type definition and we must grab type directly from value
   if(!value) {
     throw new errors.SchemaError('Invalid attribute value: ' + value);
@@ -156,7 +156,7 @@ Attribute.prototype.setTypeFromRawValue = function(value) {
 
   var type;
   var typeVal = value;
-  if (value.type){
+  if (value.type && !ignoreType){
     typeVal = value.type;
   }
 
@@ -568,16 +568,16 @@ Attribute.prototype.parseDynamo = function(json) {
 
 
 
-module.exports.create = function(schema, name, obj) {
+module.exports.create = function(schema, name, obj, ignoreType) {
 
 
   var value = obj;
   var options = {};
-  if(typeof obj === 'object' && obj.type) {
+  if(typeof obj === 'object' && obj.type && !ignoreType) {
     options = obj;
   }
 
-  var attr = new Attribute(schema, name, value);
+  var attr = new Attribute(schema, name, value, ignoreType);
 
   if(options.hashKey && options.rangeKey) {
     throw new errors.SchemaError('Cannot be both hashKey and rangeKey: ' + name);

--- a/lib/Schema.js
+++ b/lib/Schema.js
@@ -146,7 +146,7 @@ Schema.prototype.toDynamo = function(model) {
     attr = this.attributes[name];
 
     if(!attr & this.options.saveUnknown) {
-      attr = Attribute.create(this, name, model[name]);
+      attr = Attribute.create(this, name, model[name], true);
       this.attributes[name] = attr;
     }
   }

--- a/test/Model.js
+++ b/test/Model.js
@@ -204,6 +204,66 @@ describe('Model', function (){
 
   });
 
+  it('Saves unnamed attribute value that is an object with dynamoose attribute properties', function (done) {
+    var schema = Cats.Cat1.$__.schema;
+
+    var kitten = new Cats.Cat1(
+      {
+        id: 2,
+        name: 'Fluffy',
+        unnamedObjAttr: {
+          prop1: 'value1',
+          prop2: 'value2',
+          type: 'type',
+          hashKey: 'hashKey',
+          rangeKey: 'rangeKey',
+          required: 'required',
+          index: 'index',
+          default: 'default',
+          forDefault: 'forDefault',
+          validate: 'validate',
+          set: 'set',
+          get: 'get',
+          toDynamo: 'toDynamo',
+          fromDynamo: 'fromDynamo',
+          trim: 'trim',
+          lowercase: 'lowercase',
+          uppercase: 'uppercase',
+        },
+      }
+    );
+
+    var dynamoObj = schema.toDynamo(kitten);
+
+    dynamoObj.should.eql(
+      {
+        id:  {N: '2'},
+        name: {S: 'Fluffy'},
+        unnamedObjAttr: {
+          M: {
+            prop1: {S: 'value1'},
+            prop2: {S: 'value2'},
+            type: {S: 'type'},
+            hashKey: {S: 'hashKey'},
+            rangeKey: {S: 'rangeKey'},
+            required: {S: 'required'},
+            index: {S: 'index'},
+            default: {S: 'default'},
+            forDefault: {S: 'forDefault'},
+            validate: {S: 'validate'},
+            set: {S: 'set'},
+            get: {S: 'get'},
+            toDynamo: {S: 'toDynamo'},
+            fromDynamo: {S: 'fromDynamo'},
+            trim: {S: 'trim'},
+            lowercase: {S: 'lowercase'},
+            uppercase: {S: 'uppercase'},
+          },
+        },
+      });
+    kitten.save(done);
+  });
+
   it('Create complex model with unnamed attributes', function (done) {
 
 


### PR DESCRIPTION
So when saveUnknown is true, trying to save a model with an attribute that is an object can cause problems if the object has properties that match dynamoose's attribute definition options (type, required, hashKey)

For example say I want to include information about a cat's collar:

```javascript
var schema = { name: { type: String, hashKey: true }};
var options = { useDocumentTypes: true, saveUnknown: true };
var Cat = dynamoose.model('Cat', schema, options);

var cat = new Cat({ name: 'Fluffy', collar: { color: 'red', type: 'flat' }});
cat.save();
```

In DynamoDB the cat would look like:
```javascript
{
  name:  {S: 'Fluffy'},
  collar: {S: '[object Object]'}
}
```
The collar attribute isn't the expected map type because it had a `type` property and the `Attribute.setTypeFromRawValue` ends up using `collar.type` ('flat', a string value) as the value to determine the dynamo type of the attribute.

Then `toDynamo` calls `.toString()` on the `collar` object which returns `[object Object]`.

This PR changes `Schema.toDynamo` so it calls `Attribute.create` with an extra flag (`ignoreType`) that will causes the attribute not use the `value.type` property when setting the type.

It solves my specific use case (storing nested attributes that are objects with a `type` property), but I'm not 100% sure if this is the best way to handle this. 

If this PR isn't a good idea then we should consider at least adding a note about this behavior to the docs for the `saveUnknown` option or maybe emitting a warning or throwing an error if a model is being saved with "type" as the nested attribute name.