### PR TITLE
Fix loading document type attributes from DynamoDB when when saveUnknown=true

### DIFF
--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -160,14 +160,17 @@ Attribute.prototype.setTypeFromRawValue = function(value) {
     typeVal = value.type;
   }
 
-  if (util.isArray(typeVal)){
+  if (util.isArray(typeVal) || typeVal === 'list'){
     type = 'List';
   } else if ( (util.isArray(typeVal) && typeVal.length === 1) || typeof typeVal === 'function') {
     this.isSet = util.isArray(typeVal);
     var regexFuncName = /^Function ([^(]+)\(/i;
     var found = typeVal.toString().match(regexFuncName);
     type = found[1];
-  } else if (typeof typeVal === 'object'){
+    if (type === 'Object') {
+      type = 'Map';
+    }
+  } else if (typeof typeVal === 'object' || typeVal === 'map'){
     type = 'Map';
   } else {
     type = typeof typeVal;
@@ -566,6 +569,56 @@ Attribute.prototype.parseDynamo = function(json) {
   return val;
 };
 
+
+/*
+ * Converts DynamoDB document types (Map and List) to dynamoose
+ * attribute definition map and ist types
+ *
+ * For example, DynamoDB value:
+ * {
+ *   M: {
+ *     subAttr1: { S: '' },
+ *     subAttr2: { N: '' },
+ *   }
+ * }
+ *
+ * to
+ * {
+ *   type: 'map',
+ *   map: {
+ *     subAttr1: { type: String },
+ *     subAttr1: { type: Number },
+ *   },
+ * }
+ */
+function createAttrDefFromDynamo(dynamoAttribute) {
+  var dynamoType;
+  var attrDef = {
+    type: module.exports.lookupType(dynamoAttribute),
+  };
+  if (attrDef.type === Object) {
+    attrDef.type = 'map';
+    for (dynamoType in dynamoAttribute) {
+      attrDef.map = {};
+      for (var subAttrName in dynamoAttribute[dynamoType]) {
+        attrDef.map[subAttrName] = createAttrDefFromDynamo(dynamoAttribute[dynamoType][subAttrName]);
+      }
+    }
+  } else if (attrDef.type === Array) {
+    attrDef.type = 'list';
+    for (dynamoType in dynamoAttribute) {
+      attrDef.list = dynamoAttribute[dynamoType].map(createAttrDefFromDynamo);
+    }
+  }
+  return attrDef;
+}
+
+
+module.exports.createUnknownAttrbuteFromDynamo = function(schema, name, dynamoAttribute) {
+  var attrDef = createAttrDefFromDynamo(dynamoAttribute);
+  var attr = new Attribute(schema, name, attrDef);
+   return attr;
+};
 
 
 module.exports.create = function(schema, name, obj) {

--- a/lib/Schema.js
+++ b/lib/Schema.js
@@ -175,9 +175,8 @@ Schema.prototype.parseDynamo = function(model, dynamoObj) {
   for(var name in dynamoObj) {
     var attr = this.attributes[name];
 
-    if(!attr & this.options.saveUnknown) {
-      var type = Attribute.lookupType(dynamoObj[name]);
-      attr = Attribute.create(this, name, type);
+    if(!attr && this.options.saveUnknown) {
+      attr = Attribute.createUnknownAttrbuteFromDynamo(this, name, dynamoObj[name]);
       this.attributes[name] = attr;
     }
 
@@ -191,6 +190,8 @@ Schema.prototype.parseDynamo = function(model, dynamoObj) {
       if (attrVal !== undefined && attrVal !== null) {
         model[name] = attrVal;
       }
+    } else {
+      debug('parseDynamo: received an attribute name (%s) that is not defined in the schema', name);
     }
   }
 

--- a/test/Model.js
+++ b/test/Model.js
@@ -112,7 +112,7 @@ describe('Model', function (){
     Cats.Cat2.should.have.property('name');
     // Older node doesn't support Function.name changes
     if (Object.getOwnPropertyDescriptor(Function, 'name').configurable) {
-      Cats.Cat2.name.should.eql('Model-test-Cat2');
+      Cats.Cat2.name.should.eql('Model-test-Cat2-db');
     }
 
     Cats.Cat2.should.have.property('$__');
@@ -149,7 +149,7 @@ describe('Model', function (){
     Cats.Cat5.should.have.property('name');
     // Older node doesn't support Function.name changes
     if (Object.getOwnPropertyDescriptor(Function, 'name').configurable) {
-      Cats.Cat5.name.should.eql('Model-test-Cat5');
+      Cats.Cat5.name.should.eql('Model-test-Cat5-db');
     }
 
     Cats.Cat5.should.have.property('$__');
@@ -212,7 +212,7 @@ describe('Model', function (){
     Cats.Cat1.should.have.property('name');
     // Older node doesn't support Function.name changes
     if (Object.getOwnPropertyDescriptor(Function, 'name').configurable) {
-      Cats.Cat1.name.should.eql('Model-test-Cat1');
+      Cats.Cat1.name.should.eql('Model-test-Cat1-db');
     }
 
     Cats.Cat1.should.have.property('$__');

--- a/test/Schema.js
+++ b/test/Schema.js
@@ -836,7 +836,7 @@ describe('Schema tests', function (){
     done();
   });
 
-  it('parses document types when saveUnknown=false and useDocumentTypes=true', function (done) {
+  it('Parses document types when saveUnknown=false and useDocumentTypes=true', function (done) {
 
     var schema = new Schema({
       id: Number,
@@ -850,6 +850,7 @@ describe('Schema tests', function (){
       },
     }, {
       useDocumentTypes: true,
+      saveUnknown: false,
     });
 
     var model = {};
@@ -884,7 +885,7 @@ describe('Schema tests', function (){
     done();
   });
 
-  it('parses document types when saveUnknown=true and useDocumentTypes=true', function (done) {
+  it('Parses document types when saveUnknown=true and useDocumentTypes=true', function (done) {
 
     var schema = new Schema({
       id: Number,

--- a/test/Schema.js
+++ b/test/Schema.js
@@ -811,7 +811,7 @@ describe('Schema tests', function (){
   });
 
 
-  it('Handle unknow attributes in DynamoDB', function (done) {
+  it('Handle unknown attributes in DynamoDB', function (done) {
 
     var unknownSchema = new Schema({
      id: Number
@@ -833,6 +833,95 @@ describe('Schema tests', function (){
       anObject: { a: 'attribute' },
       numberString: 1,
     });
+    done();
+  });
+
+  it('parses document types when saveUnknown=false and useDocumentTypes=true', function (done) {
+
+    var schema = new Schema({
+      id: Number,
+      mapAttrib: {
+        aString: String,
+        aNumber: Number,
+      },
+      listAttrib: {
+        type: 'list',
+        list: [String],
+      },
+    }, {
+      useDocumentTypes: true,
+    });
+
+    var model = {};
+    schema.parseDynamo(model, {
+      id: { N: '2' },
+      mapAttrib: {
+        M: {
+          aString: { S: 'Fluffy' },
+          aNumber: { N: '5' },
+        },
+      },
+      listAttrib: {
+        L: [
+          { S: 'v1' },
+          { S: 'v2' },
+        ],
+      },
+    });
+
+    model.should.eql({
+      id: 2,
+      mapAttrib: {
+        aString: 'Fluffy',
+        aNumber: 5,
+      },
+      listAttrib: [
+        'v1',
+        'v2',
+      ],
+    });
+
+    done();
+  });
+
+  it('parses document types when saveUnknown=true and useDocumentTypes=true', function (done) {
+
+    var schema = new Schema({
+      id: Number,
+    }, {
+      useDocumentTypes: true,
+      saveUnknown: true,
+    });
+
+    var model = {};
+    schema.parseDynamo(model, {
+      id: { N: '2' },
+      mapAttrib: {
+        M: {
+          aString: { S: 'Fluffy' },
+          aNumber: { N: '5' },
+        },
+      },
+      listAttrib: {
+        L: [
+          { S: 'v1' },
+          { S: 'v2' },
+        ],
+      },
+    });
+
+    model.should.eql({
+      id: 2,
+      mapAttrib: {
+        aString: 'Fluffy',
+        aNumber: 5,
+      },
+      listAttrib: [
+        'v1',
+        'v2',
+      ],
+    });
+
     done();
   });
 });


### PR DESCRIPTION
This PR fixes an issue when using `saveUnknown` + `useDocumentTypes` and trying to retrieve  a model that hasn't yet been "used" for example:

```javascript
  var Cat = new Schema({
    id: Number,
  }, {
    useDocumentTypes: true,
    saveUnknown: true,
  });

  // Assume an item is in the Cat table:
  // {
  //   id: { N: '1' }
  //   petProperties: {
  //     M: {
  //       name: { S: 'Fluffy' },
  //       age: { N: 10 },
  //     }
  //   }
  // }

  Cat.get({ id: 1}};

  // throws SyntaxError: Unexpected token o in JSON at position 1
```

This is because since the Cat schema doesn't have `getProperties` attribute `Schema.parseDynamo` will create an new attribute with an `Object` type because `Attribute.lookupType` returns `Object` for Dynamo "'M" types.

This then causes the `Attribute.parseDynamo` to be parsed using `JSON.parse` instead of the correct `mapify`.

Interestingly this error doesn't happen if the model has been used to create (or put/save) before doing get/query/scan.

```javascript
  var Cat = new Schema({
    id: Number,
  }, {
    useDocumentTypes: true,
    saveUnknown: true,
  });

  Cat.create({
    id : 1,
    petProperties: {
      name: 'Fluffy',
      age: 10,
    },
  );

  // Cat's schema now has a petProperties attribute

  Cat.get({ id: 1}};

  // No error
```

This is because when `Cat.create` runs, it creates the `petProperties` attribute in the model's schema, and when `Cat.get` runs, `Schema.parseDynamo` see that is has `petProperties` and doesn't try to create a new, incorrectly-typed `Attribute`.