### PR TITLE
Fix scanByRawFilter containing - Select: 'COUNT'

### DIFF
--- a/lib/Scan.js
+++ b/lib/Scan.js
@@ -74,6 +74,10 @@ Scan.prototype.exec = function (next) {
           if (!data) {
             return deferred.resolve([]);
           }
+          if (!data.Items) {
+            var counts = { count: data.Count, scannedCount: data.ScannedCount };
+            return deferred.resolve(counts);
+          }
           return deferred.resolve(data.Items.map(function (item) {
             var model;
 

--- a/test/Scan.js
+++ b/test/Scan.js
@@ -697,6 +697,28 @@ describe('Scan', function (){
         done();
       });
   });
+  
+  it('Scan using raw AWS filter and select count', function (done) {
+    var Dog = dynamoose.model('Dog');
+    var filter = {
+      FilterExpression: 'details.timeWakeUp = :wakeUp',
+      ExpressionAttributeValues: {
+        ':wakeUp': '8am'
+      },
+      Select: 'COUNT'
+    };
+
+    Dog.scan(filter, { useRawAwsFilter: true }).exec()
+      .then(function(counts) {
+        counts.count.should.eql(1);
+        done();
+      })
+      .catch(function(err) {
+        should.not.exist(err);
+        console.error(err);
+        done();
+      });
+  });
 
   it('Raw AWS filter should return model instances', function (done) {
     var Dog = dynamoose.model('Dog');


### PR DESCRIPTION
Trying to do a Select: 'COUNT' on a raw filter scan like:

```
var Dog = dynamoose.model('Dog');
var filter = {
  FilterExpression: 'details.timeWakeUp = :wakeUp',
  ExpressionAttributeValues: {
    ':wakeUp': '8am'
  },
  Select: 'COUNT'
};
Dog.scan(filter, { useRawAwsFilter: true }).exec()
```

generates this error:

```
Uncaught TypeError: Cannot read property 'map' of undefined
      at Response.<anonymous> (node_modules/dynamoose/lib/Scan.js:82:45)
```

Intercept the case where a raw filter scan where data is defined but data.Items is unpopulated and therefore by elimination the filter must have contained ```Select: 'COUNT'```