### PR TITLE
added support for specifying the ReturnValues option in update

### DIFF
--- a/docs/_docs/model.md
+++ b/docs/_docs/model.md
@@ -386,6 +386,18 @@ A map of values for the condition expression. Note that in order for
 automatic object conversion to work, the keys in this object must
 match schema attribute names.
 
+**returnValues**: string
+
+From [the AWS documentation](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateItem.html)
+Use ReturnValues if you want to get the item attributes as they appear before or after they are updated. For UpdateItem, the valid values are:
+
+- NONE - If ReturnValues is not specified, or if its value is NONE, then nothing is returned. (This setting is the default for ReturnValues.)
+- ALL_OLD - Returns all of the attributes of the item, as they appeared before the UpdateItem operation.
+- UPDATED_OLD - Returns only the updated attributes, as they appeared before the UpdateItem operation.
+- ALL_NEW - Returns all of the attributes of the item, as they appear after the UpdateItem operation.
+- UPDATED_NEW - Returns only the updated attributes, as they appear after the UpdateItem operation.
+
+
 ### Model.getTableReq()
 
 The function will return the object used to create the table with AWS. You can use this to create the table manually, for things like the Serverless deployment toolkit, or just to peak behind the scenes and see what Dynamoose is doing to create the table.

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -523,6 +523,11 @@ Model.update = function(NewModel, key, update, options, next) {
     options.updateTimestamps = true;
   }
 
+  // default return values to 'NEW_ALL'
+  if (typeof options.returnValues === 'undefined') {
+    options.returnValues = 'ALL_NEW';
+  }
+
   // if the key part was emtpy, try the key defaults before giving up...
   if (key === null || key === undefined) {
     key = {};
@@ -562,7 +567,7 @@ Model.update = function(NewModel, key, update, options, next) {
     Key: {},
     ExpressionAttributeNames: {},
     ExpressionAttributeValues: {},
-    ReturnValues: 'ALL_NEW'
+    ReturnValues: options.returnValues
   };
   processCondition(updateReq, options, NewModel.$__.schema);
 

--- a/test/Model.js
+++ b/test/Model.js
@@ -1093,7 +1093,17 @@ describe('Model', function (){
       });
     });
 
-    it("Update returns updated new values using 'UPDATED_NEW' option", function () {
+    it("Update returns all new values using default returnValues option", function () {
+      return Cats.Cat.create({id: '678', name: 'Oliver'}, {overwrite: true}).then(function(old){
+        return Cats.Cat.update({id: old.id}, {name: 'Tom'}).then(function(data){
+          should.exist(data);
+          data.name.should.equal('Tom');
+          data.should.have.property('id');
+        });
+      });
+    });
+
+    it("Update returns updated new values using 'UPDATED_NEW'", function () {
       return Cats.Cat.create({id: '678', name: 'Oliver'}, {overwrite: true}).then(function(old){
         return Cats.Cat.update({id: old.id}, {name: 'Tom'}, {returnValues: 'UPDATED_NEW'}).then(function(data){
           should.exist(data);
@@ -1103,7 +1113,7 @@ describe('Model', function (){
       });
     });
 
-    it("Update returns all new values using 'ALL_NEW' option", function () {
+    it("Update returns all new values using 'ALL_NEW'", function () {
       return Cats.Cat.create({id: '678', name: 'Oliver'}, {overwrite: true}).then(function(old){
         return Cats.Cat.update({id: old.id}, {name: 'Tom'}, {returnValues: 'ALL_NEW'}).then(function(data){
           should.exist(data);
@@ -1113,7 +1123,7 @@ describe('Model', function (){
       });
     });
 
-    it("Update returns old updated values using 'UPDATED_OLD' option", function () {
+    it("Update returns old updated values using 'UPDATED_OLD'", function () {
       return Cats.Cat.create({id: '679', name: 'Oliver'}, {overwrite: true}).then(function(old){
         return Cats.Cat.update({id: old.id}, {name: 'Tom'}, {returnValues: 'UPDATED_OLD'}).then(function(data){
           should.exist(data);
@@ -1123,7 +1133,7 @@ describe('Model', function (){
       });
     });
 
-    it("Update returns old values using 'ALL_OLD' option", function () {
+    it("Update returns old values using 'ALL_OLD'", function () {
       return Cats.Cat.create({id: '679', name: 'Oliver'}, {overwrite: true}).then(function(old){
         return Cats.Cat.update({id: old.id}, {name: 'Tom'}, {returnValues: 'ALL_OLD'}).then(function(data){
           should.exist(data);

--- a/test/Model.js
+++ b/test/Model.js
@@ -1092,6 +1092,55 @@ describe('Model', function (){
         });
       });
     });
+
+    it("Update returns updated new values using 'UPDATED_NEW' option", function () {
+      return Cats.Cat.create({id: '678', name: 'Oliver'}, {overwrite: true}).then(function(old){
+        return Cats.Cat.update({id: old.id}, {name: 'Tom'}, {returnValues: 'UPDATED_NEW'}).then(function(data){
+          should.exist(data);
+          data.name.should.equal('Tom');
+          data.should.not.have.property('id');
+        });
+      });
+    });
+
+    it("Update returns all new values using 'ALL_NEW' option", function () {
+      return Cats.Cat.create({id: '678', name: 'Oliver'}, {overwrite: true}).then(function(old){
+        return Cats.Cat.update({id: old.id}, {name: 'Tom'}, {returnValues: 'ALL_NEW'}).then(function(data){
+          should.exist(data);
+          data.name.should.equal('Tom');
+          data.should.have.property('id');
+        });
+      });
+    });
+
+    it("Update returns old updated values using 'UPDATED_OLD' option", function () {
+      return Cats.Cat.create({id: '679', name: 'Oliver'}, {overwrite: true}).then(function(old){
+        return Cats.Cat.update({id: old.id}, {name: 'Tom'}, {returnValues: 'UPDATED_OLD'}).then(function(data){
+          should.exist(data);
+          data.name.should.equal('Oliver');
+          data.should.not.have.property('id');
+        });
+      });
+    });
+
+    it("Update returns old values using 'ALL_OLD' option", function () {
+      return Cats.Cat.create({id: '679', name: 'Oliver'}, {overwrite: true}).then(function(old){
+        return Cats.Cat.update({id: old.id}, {name: 'Tom'}, {returnValues: 'ALL_OLD'}).then(function(data){
+          should.exist(data);
+          data.name.should.equal('Oliver');
+          data.should.have.property('id');
+        });
+      });
+    });
+
+    it("Update returns should not return any values using 'none' option", function () {
+      return Cats.Cat.create({id: '680', name: 'Oliver'}, {overwrite: true}).then(function(old){
+        return Cats.Cat.update({id: old.id}, {name: 'Tom'}, {returnValues: 'NONE'}).then(function(data){
+          should.not.exist(data);
+        });
+      });
+    });
+
   });
 
   describe('Model.populate', function (){


### PR DESCRIPTION
```Model.update``` always returns all the new values in every call. This can have a severe performance penalty in some scenarios. This PR provides a backwards compatible option ```returnValues``` when calling ```update``` so that the 5 different settings provided by Dynamo can be used:

- NONE - If ReturnValues is not specified, or if its value is NONE, then nothing is returned. (This setting is the default for ReturnValues.)
- ALL_OLD - Returns all of the attributes of the item, as they appeared before the UpdateItem operation.
- UPDATED_OLD - Returns only the updated attributes, as they appeared before the UpdateItem operation.
- ALL_NEW - Returns all of the attributes of the item, as they appear after the UpdateItem operation.
- UPDATED_NEW - Returns only the updated attributes, as they appear after the UpdateItem operation.