### PR TITLE
Recreate dynamo db instance on .local()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,8 +3,15 @@
 var Schema = require('./Schema');
 var Model = require('./Model');
 var https = require('https');
+var AWS = require('aws-sdk');
 
 var debug = require('debug')('dynamoose');
+
+function createLocalDb(endpointURL) {
+  return new AWS.DynamoDB({
+    endpoint: new AWS.Endpoint(endpointURL)
+  });
+}
 
 function Dynamoose () {
   this.models = {};
@@ -50,10 +57,11 @@ Dynamoose.prototype.model = function(name, schema, options) {
 
 Dynamoose.prototype.VirtualType = require('./VirtualType');
 
-Dynamoose.prototype.AWS = require('aws-sdk');
+Dynamoose.prototype.AWS = AWS;
 
 Dynamoose.prototype.local = function (url) {
   this.endpointURL = url || 'http://localhost:8000';
+  this.dynamoDB = createLocalDb(this.endpointURL);
   debug('Setting DynamoDB to local (%s)', this.endpointURL);
 };
 
@@ -78,11 +86,10 @@ Dynamoose.prototype.ddb = function () {
   if(this.dynamoDB) {
     return this.dynamoDB;
   }
+
   if(this.endpointURL) {
     debug('Setting DynamoDB to %s', this.endpointURL);
-    this.dynamoDB = new this.AWS.DynamoDB({
-      endpoint: new this.AWS.Endpoint(this.endpointURL)
-    });
+    this.dynamoDB = createLocalDb(this.endpointURL);
   } else {
     debug('Getting default DynamoDB');
     this.dynamoDB = new this.AWS.DynamoDB({

--- a/test/LocalDB.js
+++ b/test/LocalDB.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var dynamoose = require('../');
+dynamoose.AWS.config.update({
+  accessKeyId: 'AKID',
+  secretAccessKey: 'SECRET',
+  region: 'us-east-1'
+});
+
+var should = require('should');
+
+describe('Local DB tests', function () {
+  afterEach(function() {
+    dynamoose.local();
+  });
+
+  it('Change to local dynamo db', function () {
+    dynamoose.dynamoDB = undefined;
+    var dynamoDB = dynamoose.ddb();
+    should.equal(dynamoDB.endpoint.href, 'http://localhost:8000/');
+
+    var expectURL = 'http://localhost:9000/';
+    dynamoose.local(expectURL);
+    dynamoDB = dynamoose.ddb();
+
+    should.equal(dynamoDB.endpoint.href, expectURL);
+   });
+});


### PR DESCRIPTION
The current solution requires .local() to be called first in order to
use dynamo db locally.

Recreating dynamo db instance when calling .local() solves issues like
script import order.

Example:
```javascript

// evil-cat.js
import dynamoose from 'dynamoose';

export const EvilCat = dynamoose.model('Cat', { id: Number, name: String });

// evil-cat.test.js
import dynamoose from 'dynamoose';
import { EvilCat } from 'db/evil-cat';

beforeAll(() => {
  dynamoose.local(); // won't work because dynamoose was already initialized inside of evil-cat.js 
});
```
