### PR TITLE
Update the return type of ddb()

### DIFF
--- a/dynamoose.d.ts
+++ b/dynamoose.d.ts
@@ -5,7 +5,7 @@ declare module "dynamoose" {
   export var AWS: typeof _AWS;
 
   export function local(url: string): void;
-  export function ddb(): typeof _AWS.DynamoDB;
+  export function ddb(): _AWS.DynamoDB;
 
   export function model<DataSchema, KeySchema>(
     modelName: string,


### PR DESCRIPTION
This is giving type error when we called the function and when we corrected the type to _AWS.DynamoDB instead of typeof _AWS.DynamoDB error is gone.