### PR TITLE
Updated types

### DIFF
--- a/dynamoose.d.ts
+++ b/dynamoose.d.ts
@@ -38,7 +38,8 @@ declare module "dynamoose" {
 
   
   export interface RawSchemaAttributeDefinition<Constructor, Type> {
-    [key: string]: SchemaAttributeDefinition<Constructor, Type>
+    [key: string]: SchemaAttributeDefinition<Constructor, Type> 
+      | RawSchemaAttributeDefinition<Constructor, Type>;
   }
   export interface SchemaAttributeDefinition<Constructor, Type> {
     type: Constructor;

--- a/dynamoose.d.ts
+++ b/dynamoose.d.ts
@@ -256,7 +256,7 @@ declare module "dynamoose" {
     all(delay?: number, max?: number): ScanInterface<T>;
     parallel(totalSegments: number): ScanInterface<T>;
     using(indexName: string): ScanInterface<T>;
-    consistent(filter: any): ScanInterface<T>;
+    consistent(filter?: any): ScanInterface<T>;
     where(filter: any): ScanInterface<T>;
     filter(filter: any): ScanInterface<T>;
     and(): ScanInterface<T>;

--- a/dynamoose.d.ts
+++ b/dynamoose.d.ts
@@ -9,7 +9,7 @@ declare module "dynamoose" {
 
   export function model<DataSchema, KeySchema>(
     modelName: string,
-    schema: Schema,
+    schema: Schema | SchemaAttributes,
     options?: ModelOption
   ): ModelConstructor<DataSchema, KeySchema>;
   export function setDefaults(options: ModelOption): void;

--- a/dynamoose.d.ts
+++ b/dynamoose.d.ts
@@ -165,10 +165,10 @@ declare module "dynamoose" {
     create(item: DataSchema, options?: PutOptions): Promise<ModelSchema<DataSchema>>;        
 
     get(key: KeySchema, callback?: (err: Error, data: DataSchema) => void): Promise<ModelSchema<DataSchema> | undefined>;
-    batchGet(key: KeySchema, callback?: (err: Error, data: DataSchema) => void): Promise<ModelSchema<DataSchema>[]>;
+    batchGet(key: KeySchema[], callback?: (err: Error, data: DataSchema) => void): Promise<ModelSchema<DataSchema>[]>;
 
     delete(key: KeySchema, callback?: (err: Error) => void): Promise<undefined>;
-    batchDelete(keys: KeySchema, callback?: (err: Error) => void): Promise<undefined>;
+    batchDelete(keys: KeySchema[], callback?: (err: Error) => void): Promise<undefined>;
 
     query(query: QueryFilter, callback?: (err: Error, results: ModelSchema<DataSchema>[]) => void): QueryInterface<ModelSchema<DataSchema>, QueryResult<ModelSchema<DataSchema>>>;
     queryOne(query: QueryFilter, callback?: (err: Error, results: ModelSchema<DataSchema>) => void): QueryInterface<ModelSchema<DataSchema>, ModelSchema<DataSchema>>;


### PR DESCRIPTION
- Make `filter` parameter optional in `Scan.consistent()`
- Allow `RawSchemaAttributeDefinition` to have properties of both type `SchemaAttributeDefinition` and `RawSchemaAttributeDefinition`
- Allow `dynamoose.model()` constructor to accept `Schema` or `SchemaAttributes`