### PR TITLE
Static methods are automatically bound with the context of their Model.

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -242,7 +242,7 @@ var applyMethods = function(model, schema) {
 var applyStatics = function(model, schema) {
   debug('applying statics');
   for (var i in schema.statics) {
-    model[i] = schema.statics[i];
+    model[i] = schema.statics[i].bind(model);
    }
 };
 

--- a/test/Schema.js
+++ b/test/Schema.js
@@ -635,6 +635,32 @@ describe('Schema tests', function (){
     });
   });
 
+  it('Schema with bound static methods', function (done) {
+
+    dynamoose.setDefaults({ prefix: '' });
+
+    var staticSchema = new Schema({
+     name: String
+    });
+
+    staticSchema.static('getKittensNamePunctuation', function (){
+      return '!';
+    });
+
+    staticSchema.static('findKittenName', function (name){
+      // Inside a static method "this" refers to the Model
+      return name + '\'s kitten' + this.getKittensNamePunctuation();
+    });
+
+    var Cat = dynamoose.model('Cat' + Date.now(), staticSchema);
+    var kittenOwners = ['Sue', 'Janice'];
+    var kittens = kittenOwners.map(Cat.findKittenName);
+
+    kittens.should.eql(['Sue\'s kitten!', 'Janice\'s kitten!']);
+
+    done();
+  });
+
 
   it('Schema with added virtual methods', function (done) {
 


### PR DESCRIPTION
This change automatically binds any applied static methods with the Model as the context. This is useful when passing a static method as a reference (for example to an array method).

e.g.
```javascript
const userSchema = new Schema({ ... });

userSchema.statics.getById = function getUserById(id) {
  return this.queryOne('id').eq(id).exec();         
};

const User = dynamoose.model('User', userSchema);
const userIds = ['xxxx', 'yyyy'];
const users = await Promise.all(userIds.map(User.getById));
```