### PR TITLE
Only use JSON.parse to check for Objects

### DIFF
--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -682,8 +682,7 @@ module.exports.create = function(schema, name, obj) {
 module.exports.lookupType = function (dynamoObj) {
 if(dynamoObj.S !== null && dynamoObj.S !== undefined) {
   try {
-    JSON.parse(dynamoObj.S);
-    return Object;
+    return JSON.parse(dynamoObj.S) instanceof Object ? Object : String;
   } catch (err) {
     return String;
   }


### PR DESCRIPTION
To Reproduce:

```
const db = dynamoose.model('db', new dynamoose.Schema({
  id: { type: String, hashKey: true}
}), {
  saveUnknown: true
});

db.create({
  id: 'foobar',
  unknown: '12345',
}).then(() => {
  db.get({ id: 'foobar' }).then(console.log);
});
```

This issue came up because I am storing a number as a string and `JSON.parse('12345')` does not throw. (Neither does `JSON.parse('true')` or `JSON.parse('false')`

In `v1.0` will dynamoose always use dynamo `Map`s and `BOOL`s? If so then we can always assume a string is a string.