### PR TITLE
[WIP] include test for stringNumber when saveUnknown && useDocumentTypes

### DIFF
--- a/test/Schema.js
+++ b/test/Schema.js
@@ -910,6 +910,7 @@ describe('Schema tests', function (){
           { S: 'v2' },
         ],
       },
+      stringNumber: { S: '1' },
     });
 
     model.should.eql({
@@ -922,6 +923,7 @@ describe('Schema tests', function (){
         'v1',
         'v2',
       ],
+      stringNumber: 1
     });
 
     done();


### PR DESCRIPTION
@fishcharlie this is the error I've been seeing when reading unknown string numbers (with `saveUnknown` and `useDocumentTypes` both set to true)