### PR TITLE
Fix the ModelError type

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -18,7 +18,7 @@ function ModelError(message) {
   this.name = this.constructor.name; //set our function’s name as error name.
   this.message = message || 'Error with model';
 }
-util.inherits(SchemaError, Error);
+util.inherits(ModelError, Error);
 
 
 function QueryError(message) {


### PR DESCRIPTION
ModelError type seems to be copied from SchemaError. This fixes the type issue.