### PR TITLE
Toggle useDocumentTypes and useNativeBooleans defaults to true

### DIFF
--- a/docs/_docs/schema.md
+++ b/docs/_docs/schema.md
@@ -202,7 +202,7 @@ var schema = new Schema({...}, {
 
 **useNativeBooleans**: boolean
 
-Store Boolean values as Boolean ('BOOL') in DynamoDB.  Default to `false` (i.e store as JSON string).
+Store Boolean values as Boolean ('BOOL') in DynamoDB.  Default to `true` (i.e store as DynamoDB boolean).
 
 
 ```js
@@ -213,7 +213,7 @@ var schema = new Schema({...}, {
 
 **useDocumentTypes**: boolean
 
-Store Objects and Arrays as Maps ('M') and Lists ('L') types in DynamoDB.  Defaults to `false` (i.e. store as JSON string)
+Store Objects and Arrays as Maps ('M') and Lists ('L') types in DynamoDB.  Defaults to `true` (i.e. store as DynamoDB maps and lists).
 
 ```js
 var schema = new Schema({...}, {

--- a/lib/Schema.js
+++ b/lib/Schema.js
@@ -108,8 +108,8 @@ function Schema(obj, options) {
     };
     this.expires = expires;
   }
-  this.useDocumentTypes = !!this.options.useDocumentTypes;
-  this.useNativeBooleans = !!this.options.useNativeBooleans;
+  this.useDocumentTypes = this.options.useDocumentTypes === undefined ? true : this.options.useDocumentTypes;
+  this.useNativeBooleans = this.options.useNativeBooleans === undefined ? true : this.options.useNativeBooleans;
   this.attributeFromDynamo = this.options.attributeFromDynamo;
   this.attributeToDynamo = this.options.attributeToDynamo;
 

--- a/test/Model.js
+++ b/test/Model.js
@@ -220,7 +220,7 @@ describe('Model', function (){
       it('Should support useDocumentTypes and useNativeBooleans being false', function(done) {
       	this.timeout(12000);
 
-      	var kitten = new Cats.Cat9({
+      	var kitten = new Cats.Cat10({
       		id: 2,
       		isHappy: true,
       		parents: ["Max", "Leah"],
@@ -250,7 +250,7 @@ describe('Model', function (){
       			tired: false
       		});
 
-      		Cats.Cat9.get(2, function(err, kitten) {
+      		Cats.Cat10.get(2, function(err, kitten) {
       			kitten.id.should.eql(2);
       			kitten.isHappy.should.eql(true);
       			kitten.parents.should.eql(["Max", "Leah"]);

--- a/test/Model.js
+++ b/test/Model.js
@@ -217,6 +217,54 @@ describe('Model', function (){
 
       });
 
+      it('Should support useDocumentTypes and useNativeBooleans being false', function(done) {
+      	this.timeout(12000);
+
+      	var kitten = new Cats.Cat9({
+      		id: 2,
+      		isHappy: true,
+      		parents: ["Max", "Leah"],
+      		details: {
+      			playful: true,
+      			thirsty: false,
+      			tired: false
+      		}
+      	});
+
+      	kitten.id.should.eql(2);
+      	kitten.isHappy.should.eql(true);
+      	kitten.parents.should.eql(["Max", "Leah"]);
+      	kitten.details.should.eql({
+      		playful: true,
+      		thirsty: false,
+      		tired: false
+      	});
+
+      	kitten.save(function(err, kitten) {
+      		kitten.id.should.eql(2);
+      		kitten.isHappy.should.eql(true);
+      		kitten.parents.should.eql(["Max", "Leah"]);
+      		kitten.details.should.eql({
+      			playful: true,
+      			thirsty: false,
+      			tired: false
+      		});
+
+      		Cats.Cat9.get(2, function(err, kitten) {
+      			kitten.id.should.eql(2);
+      			kitten.isHappy.should.eql(true);
+      			kitten.parents.should.eql(["Max", "Leah"]);
+      			kitten.details.should.eql({
+      				playful: true,
+      				thirsty: false,
+      				tired: false
+      			});
+
+      			done();
+      		});
+      	});
+      });
+
       it('Create complex model with unnamed attributes', function (done) {
 
 

--- a/test/Model.js
+++ b/test/Model.js
@@ -208,8 +208,8 @@ describe('Model', function (){
         owner: { S: 'Someone' },
         unnamedInt: { N: '1' },
         unnamedInt0: { N: '0' },
-        unnamedBooleanFalse: { S: 'false' },
-        unnamedBooleanTrue: { S: 'true' },
+        unnamedBooleanFalse: { BOOL: false },
+        unnamedBooleanTrue: { BOOL: true },
         unnamedString: { S: 'unnamed' },
       });
 

--- a/test/Schema.js
+++ b/test/Schema.js
@@ -994,6 +994,11 @@ describe('Schema tests', function (){
       name: { S: 'Fluffy' },
       anObject: { S: '{"a":"attribute"}' },
       numberString: { S: '1' },
+      anArray: { S: '[2,{"test2": "5","test": "1"},"value1"]' },
+      anObjectB: { M: {"a":{"S": "attribute"}} },
+      anArrayB: { L: [{N:'2'},{M: {'test2': {S: '5'},'test': {S: '1'}}},{S: "value1"}] },
+      aBoolean: { S: "true" },
+      aBooleanB: { BOOL: true },
     });
 
     model.should.eql({
@@ -1001,6 +1006,13 @@ describe('Schema tests', function (){
       name: 'Fluffy',
       anObject: { a: 'attribute' },
       numberString: 1,
+      // TODO: the numbers below should probably be parseInt'ed like the `numberString` attr
+      anArray: [2, {'test2': '5', 'test': '1'}, 'value1'],
+      anObjectB: { a: 'attribute' },
+      // TODO: the numbers below should probably be parseInt'ed like the `numberString` attr
+      anArrayB: [2, {'test2': '5', 'test': '1'}, 'value1'],
+      aBoolean: true,
+      aBooleanB: true
     });
     done();
   });
@@ -1021,6 +1033,11 @@ describe('Schema tests', function (){
       name: { S: 'Fluffy' },
       anObject: { S: '{"a":"attribute"}' },
       numberString: { S: '1' },
+      anArray: { S: '[2,{"test2": "5","test": "1"},"value1"]'},
+      anObjectB: { M: {"a":{"S": "attribute"}} },
+      anArrayB: { L: [{N:'2'},{M: {'test2': {S: '5'},'test': {S: '1'}}},{S: "value1"}]},
+      aBoolean: { S: "true" },
+      aBooleanB: { BOOL: true },
     });
 
     model.should.eql({
@@ -1028,6 +1045,13 @@ describe('Schema tests', function (){
       name: 'Fluffy',
       anObject: { a: 'attribute' },
       numberString: 1,
+      // TODO: the numbers below should probably be parseInt'ed like the `numberString` attr
+      anArray: [2, {'test2': '5', 'test': '1'}, 'value1'],
+      anObjectB: { a: 'attribute' },
+      // TODO: the numbers below should probably be parseInt'ed like the `numberString` attr
+      anArrayB: [2, {'test2': '5', 'test': '1'}, 'value1'],
+      aBoolean: true,
+      aBooleanB: true
     });
     done();
   });

--- a/test/Schema.js
+++ b/test/Schema.js
@@ -66,9 +66,9 @@ describe('Schema tests', function (){
 
     schema.attributes.aArray.type.name.should.eql('array');
 
-    schema.attributes.aMap.type.name.should.eql('object');
+    schema.attributes.aMap.type.name.should.eql('map');
 
-    schema.attributes.aList.type.name.should.eql('array');
+    schema.attributes.aList.type.name.should.eql('list');
 
     schema.hashKey.should.equal(schema.attributes.id); // should be same object
     should.not.exist(schema.rangeKey);
@@ -154,9 +154,9 @@ describe('Schema tests', function (){
     schema.attributes.aObject.type.name.should.eql('object');
     should.exist(schema.attributes.aObject.default);
 
-    schema.attributes.aMap.type.name.should.eql('object');
+    schema.attributes.aMap.type.name.should.eql('map');
 
-    schema.attributes.aList.type.name.should.eql('array');
+    schema.attributes.aList.type.name.should.eql('list');
 
     schema.hashKey.should.equal(schema.attributes.breed); // should be same object
     schema.rangeKey.should.equal(schema.attributes.id);
@@ -551,7 +551,7 @@ describe('Schema tests', function (){
     done();
   });
 
-  it('Schema useDocumentTypes and useNativeBooleans should default to false', function (done) {
+  it('Schema useDocumentTypes and useNativeBooleans should default to true', function (done) {
   	var schema = new Schema({
   	  id: {
     		type: Number,
@@ -599,8 +599,8 @@ describe('Schema tests', function (){
   	  }
   	});
 
-  	schema.useDocumentTypes.should.eql(false);
-  	schema.useNativeBooleans.should.eql(false);
+  	schema.useDocumentTypes.should.eql(true);
+  	schema.useNativeBooleans.should.eql(true);
   	done();
   });
 

--- a/test/Schema.js
+++ b/test/Schema.js
@@ -551,6 +551,59 @@ describe('Schema tests', function (){
     done();
   });
 
+  it('Schema useDocumentTypes and useNativeBooleans should default to false', function (done) {
+  	var schema = new Schema({
+  	  id: {
+    		type: Number,
+    		validate: function(v) { return v > 0; },
+    		rangeKey: true
+  	  },
+  	  breed: {
+    		type: String,
+    		hashKey: true
+  	  },
+  	  aObject: {
+    		type: 'Object',
+    		default: { state: 'alive' }
+  	  },
+  	  anotherObject: Object,
+  	  aArray: Array,
+  	  aMap: {
+    		mapId: Number,
+    		mapName: String,
+    		anotherMap:{
+    		  m1:String,
+    		}
+  	  },
+  	  aList:[
+    		{
+    		  listMapId: Number,
+    		  listMapName: String
+    		}
+  	  ],
+  	  anotherMap: {
+    		type: 'map',
+    		map: {
+    		  mapId: {type: Number, required:true },
+    		  mapName: {type: String, required:true }
+    		}
+  	  },
+  	  anotherList: {
+    		type: 'list',
+    		list: [
+    		  {
+    			listMapId: {type: Number, default: 1},
+    			listMapName: {type: String, default:"SomeName"}
+    		  }
+    		]
+  	  }
+  	});
+
+  	schema.useDocumentTypes.should.eql(false);
+  	schema.useNativeBooleans.should.eql(false);
+  	done();
+  });
+
 
   it('Schema with added instance methods', function (done) {
 

--- a/test/Schema.js
+++ b/test/Schema.js
@@ -1005,6 +1005,33 @@ describe('Schema tests', function (){
     done();
   });
 
+  it('Handle unknown attributes in DynamoDB when document types are set to false', function (done) {
+
+    var unknownSchema = new Schema({
+     id: Number
+     }, {
+      saveUnknown: true,
+      useDocumentTypes: false,
+      useNativeBooleans: false
+    });
+
+    var model = {};
+    unknownSchema.parseDynamo(model, {
+      id: { N: '2' },
+      name: { S: 'Fluffy' },
+      anObject: { S: '{"a":"attribute"}' },
+      numberString: { S: '1' },
+    });
+
+    model.should.eql({
+      id: 2,
+      name: 'Fluffy',
+      anObject: { a: 'attribute' },
+      numberString: 1,
+    });
+    done();
+  });
+
   it('Enum Should be set in schema attributes object', function (done) {
      var enumData = ['Golden retriever', 'Beagle'];
     var schema = new Schema({
@@ -1104,6 +1131,32 @@ describe('Schema tests', function (){
      id: Number
      }, {
       saveUnknown: ["name", "numberString"]
+    });
+
+    var model = {};
+    unknownSchema.parseDynamo(model, {
+      id: { N: '2' },
+      name: { S: 'Fluffy' },
+      anObject: { S: '{"a":"attribute"}' },
+      numberString: { S: '1' }
+    });
+
+    model.should.eql({
+      id: 2,
+      name: 'Fluffy',
+      numberString: 1
+    });
+    done();
+  });
+
+  it('Handle unknown attributes as array in DynamoDB when document types are set to false', function (done) {
+
+    var unknownSchema = new Schema({
+     id: Number
+     }, {
+      saveUnknown: ["name", "numberString"],
+      useDocumentTypes: false,
+      useNativeBooleans: false
     });
 
     var model = {};

--- a/test/Schema.js
+++ b/test/Schema.js
@@ -377,7 +377,7 @@ describe('Schema tests', function (){
           }
         ]
       }
-    }, {useDocumentTypes: true});
+    });
 
     schema.useDocumentTypes.should.be.ok;
 
@@ -416,7 +416,7 @@ describe('Schema tests', function (){
     var schema = new Schema({
      name: String,
      isAwesome: Boolean
-    }, {useNativeBooleans: true});
+    });
 
     var Cat = dynamoose.model('Cat' + Date.now(), schema);
     var fluffy = new Cat();
@@ -903,8 +903,7 @@ describe('Schema tests', function (){
         list: [String],
       },
     }, {
-      useDocumentTypes: true,
-      saveUnknown: false,
+      saveUnknown: false
     });
 
     var model = {};
@@ -944,8 +943,7 @@ describe('Schema tests', function (){
     var schema = new Schema({
       id: Number,
     }, {
-      useDocumentTypes: true,
-      saveUnknown: true,
+      saveUnknown: true
     });
 
     var model = {};

--- a/test/Schema.js
+++ b/test/Schema.js
@@ -122,7 +122,7 @@ describe('Schema tests', function (){
           }
         ]
       }
-    }, {throughput: {read: 10, write: 2}});
+    }, {throughput: {read: 10, write: 2}, useDocumentTypes: false, useNativeBooleans: false});
 
     schema.attributes.id.type.name.should.eql('number');
     should(schema.attributes.id.isSet).not.be.ok;
@@ -154,9 +154,9 @@ describe('Schema tests', function (){
     schema.attributes.aObject.type.name.should.eql('object');
     should.exist(schema.attributes.aObject.default);
 
-    schema.attributes.aMap.type.name.should.eql('map');
+    schema.attributes.aMap.type.name.should.eql('object');
 
-    schema.attributes.aList.type.name.should.eql('list');
+    schema.attributes.aList.type.name.should.eql('array');
 
     schema.hashKey.should.equal(schema.attributes.breed); // should be same object
     schema.rangeKey.should.equal(schema.attributes.id);

--- a/test/fixtures/Cats.js
+++ b/test/fixtures/Cats.js
@@ -349,7 +349,7 @@ module.exports = function(dynamoose){
     Cat7: Cat7,
     Cat8: Cat8,
     Cat9: Cat9,
-    Cat10: Cat10
+    Cat10: Cat10,
     CatWithOwner: CatWithOwner,
     Owner: Owner,
     ExpiringCat: ExpiringCat,

--- a/test/fixtures/Cats.js
+++ b/test/fixtures/Cats.js
@@ -3,7 +3,7 @@
 module.exports = function(dynamoose){
   var ONE_YEAR = 365*24*60*60; // 1 years in seconds
   var NINE_YEARS = 9*ONE_YEAR; // 9 years in seconds
-  
+
   var Cat = dynamoose.model('Cat',
   {
     id: {
@@ -27,8 +27,7 @@ module.exports = function(dynamoose){
       type: String,
       validate: function (v) { return v === 'valid'; }
     }
-  },
-  {useDocumentTypes: true});
+  });
 
   // Create a model with unnamed attributes
   var Cat1 = dynamoose.model('Cat1',
@@ -49,7 +48,6 @@ module.exports = function(dynamoose){
       // }
     },
     {
-      useDocumentTypes: true,
       saveUnknown: true
     });
 
@@ -291,7 +289,7 @@ module.exports = function(dynamoose){
 		validate: function (v) { return v === 'valid'; }
 	  }
 	},
-	{useDocumentTypes: true, timestamps: true});
+	{timestamps: true});
 
   return {
     Cat: Cat,

--- a/test/fixtures/Cats.js
+++ b/test/fixtures/Cats.js
@@ -166,6 +166,16 @@ module.exports = function(dynamoose){
     }
   );
 
+  var Cat9 = dynamoose.model('Cat9', {
+	  id: {
+  		type:  Number,
+  		hashKey: true
+	  },
+	  isHappy: Boolean,
+    parents: Array,
+    details: Object
+	}, {useDocumentTypes: false, useNativeBooleans: false});
+
   var CatWithOwner = dynamoose.model('CatWithOwner',
     {
       id: {

--- a/test/fixtures/Cats.js
+++ b/test/fixtures/Cats.js
@@ -166,16 +166,6 @@ module.exports = function(dynamoose){
     }
   );
 
-  var Cat9 = dynamoose.model('Cat9', {
-	  id: {
-  		type:  Number,
-  		hashKey: true
-	  },
-	  isHappy: Boolean,
-    parents: Array,
-    details: Object
-	}, {useDocumentTypes: false, useNativeBooleans: false});
-
   var CatWithOwner = dynamoose.model('CatWithOwner',
     {
       id: {
@@ -329,6 +319,16 @@ module.exports = function(dynamoose){
 	},
 	{timestamps: true});
 
+  var Cat10 = dynamoose.model('Cat10', {
+	  id: {
+  		type:  Number,
+  		hashKey: true
+	  },
+	  isHappy: Boolean,
+    parents: Array,
+    details: Object
+	}, {useDocumentTypes: false, useNativeBooleans: false});
+
   var CatWithMethodsSchema = new dynamoose.Schema({
     id: Number,
     name: String
@@ -349,6 +349,7 @@ module.exports = function(dynamoose){
     Cat7: Cat7,
     Cat8: Cat8,
     Cat9: Cat9,
+    Cat10: Cat10
     CatWithOwner: CatWithOwner,
     Owner: Owner,
     ExpiringCat: ExpiringCat,


### PR DESCRIPTION
I'm pretty sure this is a **🚨 breaking change 🚨**, but haven't run enough tests to verify yet.

This PR sets the useDocumentTypes and useNativeBooleans default options to `true` instead of `false`. This is the final major PR of v1.0.