### PR TITLE
Fix serverSideEncryption option

### DIFF
--- a/lib/Table.js
+++ b/lib/Table.js
@@ -141,7 +141,7 @@ Table.prototype.init = function (next) {
     this.describe()
       .then(function (data) {
         debug('table exist -- initialization done');
-        localTableReq = buildTableReq(table.name, table.schema, this);
+        localTableReq = table.buildTableReq(table.name, table.schema);
         var indexes = compareIndexes(localTableReq, data.Table);
 
         debug('%s', JSON.stringify(indexes, null, 2));
@@ -517,7 +517,7 @@ var buildTableReq = Table.prototype.buildTableReq = function buildTableReq(name,
 Table.prototype.create = function (next) {
   var ddb = this.base.ddb();
   var schema = this.schema;
-  var createTableReq = buildTableReq(this.name, schema, this);
+  var createTableReq = this.buildTableReq(this.name, schema);
 
   debug('ddb.createTable request:', createTableReq);
 

--- a/lib/Table.js
+++ b/lib/Table.js
@@ -348,7 +348,7 @@ Table.prototype.describe = function (next) {
   return deferred.promise.nodeify(next);
 };
 
-var buildTableReq = Table.prototype.buildTableReq = function buildTableReq(name, schema) {
+Table.prototype.buildTableReq = function buildTableReq(name, schema) {
   var attrDefs = [];
 
   var keyAttr = {};


### PR DESCRIPTION
There was a problem using the serverSideEncryption option due to the way buildTableReq was being called. The this parameter was being passed to the buildTableReq function but it was not being used, so the options from the table were being ignored. This PR calls the buildTableReq function as an instance function so the local this value is valid.