### PR TITLE
Fix data corruption when storing binary data

### DIFF
--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -432,7 +432,7 @@ Attribute.prototype.toDynamo = function(val, noSet, model, options) {
       val = type.dynamofy(val);
     }
 
-    if(type.dynamo !== 'BOOL') {
+    if(type.dynamo !== 'BOOL' && (type.dynamo !== 'B' || !(val instanceof Buffer))) {
       val = val.toString();
     }
 

--- a/test/Model.js
+++ b/test/Model.js
@@ -18,6 +18,10 @@ var Cats = {};
 var ONE_YEAR = 365*24*60*60; // 1 years in seconds
 var NINE_YEARS = 9*ONE_YEAR; // 9 years in seconds
 
+var imageData = Buffer.from([0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x13, 0xd3, 0x61, 0x60, 0x60]);
+imageData.should.not.eql(Buffer.from(imageData.toString())); // The binary value should not be UTF-8 string for test.
+
+
 describe('Model', function (){
   this.timeout(15000);
   before(function(done) {
@@ -74,6 +78,7 @@ describe('Model', function (){
         vet:{name:'theVet', address:'12 somewhere'},
         ears:[{name:'left'}, {name:'right'}],
         legs: ['front right', 'front left', 'back right', 'back left'],
+        profileImage: imageData,
         more: {fovorites: {food: 'fish'}},
         array: [{one: '1'}],
         validated: 'valid'
@@ -97,6 +102,7 @@ describe('Model', function (){
         name: { S: 'Fluffy' },
         vet: { M: { address: { S: '12 somewhere' }, name: { S: 'theVet' } } },
         legs: { SS: ['front right', 'front left', 'back right', 'back left']},
+        profileImage: { B: imageData },
         more: { S: '{"fovorites":{"food":"fish"}}' },
         array: { S: '[{"one":"1"}]' },
         validated: { S: 'valid' }
@@ -319,6 +325,7 @@ describe('Model', function (){
       model.should.have.property('id', 1);
       model.should.have.property('name', 'Fluffy');
       model.should.have.property('vet', { address: '12 somewhere', name: 'theVet' });
+      model.should.have.property('profileImage', imageData);
       model.should.have.property('$__');
       done();
     });

--- a/test/Model.js
+++ b/test/Model.js
@@ -18,10 +18,6 @@ var Cats = {};
 var ONE_YEAR = 365*24*60*60; // 1 years in seconds
 var NINE_YEARS = 9*ONE_YEAR; // 9 years in seconds
 
-var imageData = Buffer.from([0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x13, 0xd3, 0x61, 0x60, 0x60]);
-imageData.should.not.eql(Buffer.from(imageData.toString())); // The binary value should not be UTF-8 string for test.
-
-
 describe('Model', function (){
   this.timeout(15000);
   before(function(done) {
@@ -78,7 +74,6 @@ describe('Model', function (){
         vet:{name:'theVet', address:'12 somewhere'},
         ears:[{name:'left'}, {name:'right'}],
         legs: ['front right', 'front left', 'back right', 'back left'],
-        profileImage: imageData,
         more: {fovorites: {food: 'fish'}},
         array: [{one: '1'}],
         validated: 'valid'
@@ -102,7 +97,6 @@ describe('Model', function (){
         name: { S: 'Fluffy' },
         vet: { M: { address: { S: '12 somewhere' }, name: { S: 'theVet' } } },
         legs: { SS: ['front right', 'front left', 'back right', 'back left']},
-        profileImage: { B: imageData },
         more: { S: '{"fovorites":{"food":"fish"}}' },
         array: { S: '[{"one":"1"}]' },
         validated: { S: 'valid' }
@@ -325,7 +319,6 @@ describe('Model', function (){
       model.should.have.property('id', 1);
       model.should.have.property('name', 'Fluffy');
       model.should.have.property('vet', { address: '12 somewhere', name: 'theVet' });
-      model.should.have.property('profileImage', imageData);
       model.should.have.property('$__');
       done();
     });
@@ -1827,6 +1820,30 @@ describe('Model', function (){
         newCatB.name = 'NAME_VALUE_2';
         newCatB.originalItem().should.eql(item);
         newCatB.name.should.eql('NAME_VALUE_2');
+        done();
+      });
+    });
+  });
+
+  it('Should store/load binary data safely', function(done) {
+    var imageData = Buffer.from([0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x13, 0xd3, 0x61, 0x60, 0x60]);
+
+    imageData.should.not.eql(Buffer.from(imageData.toString())); // The binary value should not be UTF-8 string for test.
+
+    var item = {
+      id: 3333,
+      name: 'NAME_VALUE',
+      owner: 'OWNER_VALUE',
+      profileImage: imageData
+    };
+
+    var cat = new Cats.Cat(item);
+    cat.save(function(err) {
+      should.not.exist(err);
+      Cats.Cat.get(3333, function(err, newCatB) {
+        should.not.exist(err);
+        should.exist(newCatB);
+        newCatB.should.have.property('profileImage', imageData);
         done();
       });
     });

--- a/test/fixtures/Cats.js
+++ b/test/fixtures/Cats.js
@@ -21,6 +21,7 @@ module.exports = function(dynamoose){
       name: String
     }],
     legs: [String],
+    profileImage: Buffer,
     more: Object,
     array: Array,
     validated: {


### PR DESCRIPTION
Hello, I fixed a bug of storing corrupted binary data.

For example, following code did not properly store the value.

```javascript
const schema = new dynamoose.Schema({
    key: { type: String },
    value: { type: Buffer }
});
const Model = dynamoose.model('KVS', schema);

const s = Buffer.from([0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x13, 0xd3, 0x61, 0x60, 0x60]);
console.log(s); // <Buffer 1f 8b 08 00 00 00 00 00 00 13 d3 61 60 60>

await Model.batchPut([{ key: 'key1', value: s }]);
const c = (await Model.get({ key: 'key1' })).value;
console.log(c); // <Buffer 1f ef bf bd 08 00 00 00 00 00 00 13 ef bf bd 61 60 60>
```

Because not every binary data can be converted to UTF-8 string, also the AWS SDK supports both `Buffer` and `string` for type `B`, it is better not to convert the value to string when the type is `B` and the value is `Buffer` instance.