### PR TITLE
Updating with saveUnknown enabled

### DIFF
--- a/test/Model.js
+++ b/test/Model.js
@@ -1297,6 +1297,19 @@ describe('Model', function (){
       });
     });
 
+    it('Update with saveUnknown enabled', function (done) {
+      Cats.Cat1.create({id: 982, name: 'Oliver'}, function(err, old){
+        should.not.exist(err);
+        Cats.Cat1.update({id: old.id}, {otherProperty: 'Testing123'}, function(err, data){
+          should.not.exist(err);
+          should.exist(data);
+          data.should.have.property('otherProperty');
+          data.otherProperty.should.eql('Testing123');
+          done();
+        })
+      });
+    });
+
   });
 
   describe('Model.populate', function (){


### PR DESCRIPTION
### Summary:

This PR is adding a test for a related issue that needs to be fixed. Currently updating with `saveUnknown` enabled fails silently, and doesn't update with unknown properties.


### GitHub linked issue:
#403 


### Type (select 1):
- [ ] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
- [x] Test added to report bug (GitHub issue #403 @fishcharlie)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [ ] Yes
- [x] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [ ] I have run `npm test` from the root of the project directory to ensure all tests continue to pass
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
