### PR TITLE
Removing self = this in favor of arrow functions

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -451,9 +451,8 @@ Model.prototype.populate = function (options, resultObj, fillPath) {
   if (!fillPath) {
     fillPath = [];
   }
-  const self = this;
   if (!resultObj) {
-    resultObj = self;
+    resultObj = this;
   }
 
   let ModelPathName = '';
@@ -486,16 +485,16 @@ Model.prototype.populate = function (options, resultObj, fillPath) {
   }
 
   return Model
-  .get(self[options.path || options])
-  .then(function(target){
+  .get(this[options.path || options])
+  .then(target => {
     if (!target) {
       throw new Error('Invalid reference');
     }
-    self[options.path || options] = target;
+    this[options.path || options] = target;
     fillPath = fillPath.concat(options.path || options);
     objectPath.set(resultObj, fillPath, target);
     if (options.populate) {
-      return self[options.path || options].populate(options.populate, resultObj, fillPath);
+      return this[options.path || options].populate(options.populate, resultObj, fillPath);
     } else {
       return resultObj;
     }

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -794,521 +794,521 @@ Model.update = function(NewModel, key, update, options, next) {
         !operations.ADD[attributeName] &&
         !operations.REMOVE[attributeName]) {
 
-          let defaultValueOrFunction = attribute.options.default;
+        let defaultValueOrFunction = attribute.options.default;
 
-          // throw an error if you have required attribute without a default (and you didn't supply
-          //  anything to update with)
-          if (typeof defaultValueOrFunction === 'undefined') {
-            let err = 'Required attribute "' + attributeName + '" does not have a default.';
-            debug('Error returned by updateItem', err);
-            deferred.reject(err);
-            return deferred.promise.nodeify(next);
-          }
-
-          let defaultValue = typeof defaultValueOrFunction === 'function' ? defaultValueOrFunction() : defaultValueOrFunction;
-
-          operations.addIfNotExistsSet(attributeName, attribute.toDynamo(defaultValue));
+        // throw an error if you have required attribute without a default (and you didn't supply
+        //  anything to update with)
+        if (typeof defaultValueOrFunction === 'undefined') {
+          let err = 'Required attribute "' + attributeName + '" does not have a default.';
+          debug('Error returned by updateItem', err);
+          deferred.reject(err);
+          return deferred.promise.nodeify(next);
         }
+
+        let defaultValue = typeof defaultValueOrFunction === 'function' ? defaultValueOrFunction() : defaultValueOrFunction;
+
+        operations.addIfNotExistsSet(attributeName, attribute.toDynamo(defaultValue));
       }
     }
+  }
 
-    operations.getUpdateExpression(updateReq);
+  operations.getUpdateExpression(updateReq);
 
-    // AWS doesn't allow empty expressions or attribute collections
-    if(!updateReq.UpdateExpression) {
-      delete updateReq.UpdateExpression;
+  // AWS doesn't allow empty expressions or attribute collections
+  if(!updateReq.UpdateExpression) {
+    delete updateReq.UpdateExpression;
+  }
+  if(!Object.keys(updateReq.ExpressionAttributeNames).length) {
+    delete updateReq.ExpressionAttributeNames;
+  }
+  if(!Object.keys(updateReq.ExpressionAttributeValues).length) {
+    delete updateReq.ExpressionAttributeValues;
+  }
+
+  const newModel$ = NewModel.$__;
+
+  function updateItem () {
+    debug('updateItem', updateReq);
+    newModel$.base.ddb().updateItem(updateReq, function(err, data) {
+      if(err) {
+        debug('Error returned by updateItem', err);
+        return deferred.reject(err);
+      }
+      debug('updateItem response', data);
+
+      if(!Object.keys(data).length) {
+        return deferred.resolve();
+      }
+
+      const model = new NewModel();
+      model.$__.isNew = false;
+      try {
+        schema.parseDynamo(model, data.Attributes);
+      } catch(e){
+        debug('cannot parse data', data);
+        return deferred.reject(e);
+      }
+
+      debug('updateItem parsed model', model);
+
+      deferred.resolve(model);
+    });
+  }
+
+  if(newModel$.options.waitForActive) {
+    newModel$.table.waitForActive().then(updateItem).catch(deferred.reject);
+  } else {
+    updateItem();
+  }
+
+  return deferred.promise.nodeify(next);
+};
+
+Model.delete = function(NewModel, key, options, next) {
+
+  const schema = NewModel.$__.schema;
+
+  const hashKeyName = schema.hashKey.name;
+  if(!key[hashKeyName]) {
+    const keyVal = key;
+    key = {};
+    key[hashKeyName] = keyVal;
+  }
+
+  if(schema.rangeKey && !key[schema.rangeKey.name]) {
+    const deferred = Q.defer();
+    deferred.reject(new errors.ModelError('Range key required: %s', schema.hashKey.name));
+    return deferred.promise.nodeify(next);
+  }
+
+  const model = new NewModel(key);
+  return model.delete(options, next);
+};
+
+Model.prototype.delete = function(options, next) {
+  options = options || {};
+  if(typeof options === 'function') {
+    next = options;
+    options = {};
+  }
+
+  const schema = this.$__.schema;
+
+  const hashKeyName = schema.hashKey.name;
+
+  const deferred = Q.defer();
+
+  if(this[hashKeyName] === null || this[hashKeyName] === undefined) {
+    deferred.reject(new errors.ModelError('Hash key required: %s', hashKeyName));
+    return deferred.promise.nodeify(next);
+  }
+
+  if(schema.rangeKey && (this[schema.rangeKey.name] === null || this[schema.rangeKey.name] === undefined)) {
+    deferred.reject(new errors.ModelError('Range key required: %s', schema.hashKey.name));
+    return deferred.promise.nodeify(next);
+  }
+
+
+  const getDelete = {
+    TableName: this.$__.name,
+    Key: {}
+  };
+
+  try {
+    getDelete.Key[hashKeyName] = schema.hashKey.toDynamo(this[hashKeyName], undefined, this);
+
+    if(schema.rangeKey) {
+      const rangeKeyName = schema.rangeKey.name;
+      getDelete.Key[rangeKeyName] = schema.rangeKey.toDynamo(this[rangeKeyName], undefined, this);
     }
-    if(!Object.keys(updateReq.ExpressionAttributeNames).length) {
-      delete updateReq.ExpressionAttributeNames;
-    }
-    if(!Object.keys(updateReq.ExpressionAttributeValues).length) {
-      delete updateReq.ExpressionAttributeValues;
-    }
+  } catch (err) {
+    deferred.reject(err);
+    return deferred.promise.nodeify(next);
+  }
 
-    const newModel$ = NewModel.$__;
+  if(options.update) {
+    getDelete.ReturnValues = 'ALL_OLD';
+    getDelete.ConditionExpression = 'attribute_exists(' + schema.hashKey.name + ')';
+  }
 
-    function updateItem () {
-      debug('updateItem', updateReq);
-      newModel$.base.ddb().updateItem(updateReq, function(err, data) {
-        if(err) {
-          debug('Error returned by updateItem', err);
-          return deferred.reject(err);
-        }
-        debug('updateItem response', data);
+  const model = this;
+  const model$ = this.$__;
 
-        if(!Object.keys(data).length) {
-          return deferred.resolve();
-        }
+  function deleteItem() {
 
-        const model = new NewModel();
-        model.$__.isNew = false;
+    debug('deleteItem', getDelete);
+    model$.base.ddb().deleteItem(getDelete, function(err, data) {
+      if(err) {
+        debug('Error returned by deleteItem', err);
+        return deferred.reject(err);
+      }
+      debug('deleteItem response', data);
+
+      if(options.update && data.Attributes) {
         try {
           schema.parseDynamo(model, data.Attributes);
-        } catch(e){
-          debug('cannot parse data', data);
-          return deferred.reject(e);
+          debug('deleteItem parsed model', model);
+
+
+        } catch (err) {
+          return deferred.reject(err);
         }
+      }
 
-        debug('updateItem parsed model', model);
+      deferred.resolve(model);
+    });
+  }
 
-        deferred.resolve(model);
-      });
-    }
+  if(model$.options.waitForActive) {
+    model$.table.waitForActive().then(deleteItem).catch(deferred.reject);
+  } else {
+    deleteItem();
+  }
 
-    if(newModel$.options.waitForActive) {
-      newModel$.table.waitForActive().then(updateItem).catch(deferred.reject);
-    } else {
-      updateItem();
-    }
+  return deferred.promise.nodeify(next);
 
+};
+
+/*
+query(query, options, callback);
+query(query, options)...exec(callback);
+query(query, callback);
+query(query)...exec(callback);
+query({hash: {id: {eq : 1}}, range: {name: {beginwith: 'foxy'}}})
+query({id: 1})
+query('id').eq(1).where('name').begienwith('foxy')
+*/
+Model.query = function(NewModel, query, options, next) {
+  if(typeof options === 'function') {
+    next = options;
+    options = null;
+  }
+
+  query = new Query(NewModel, query, options);
+
+  if(next) {
+    query.exec(next);
+  }
+
+  return query;
+};
+
+Model.queryOne = function(NewModel, query, options, next) {
+  if(typeof options === 'function') {
+    next = options;
+    options = null;
+  }
+
+  query = new Query(NewModel, query, options);
+  query.one();
+
+  if(next) {
+    query.exec(next);
+  }
+
+  return query;
+};
+
+
+/*
+
+scan(filter, options, callback);
+scan(filter, options)...exec(callback);
+scan(filter, callback);
+scan(filter)...exec(callback);
+
+scan('id').between(a, b).and().where('name').begienwith('foxy').exec();
+
+scan().exec(); // All records
+
+*/
+Model.scan = function(NewModel, filter, options, next) {
+  if(typeof options === 'function') {
+    next = options;
+    options = null;
+  }
+
+  const scan = new Scan(NewModel, filter, options);
+
+  if(next) {
+    scan.exec(next);
+  }
+
+  return scan;
+};
+
+Model.batchGet = function(NewModel, keys, options, next) {
+  debug('BatchGet %j', keys);
+  const deferred = Q.defer();
+  if(!(keys instanceof Array)) {
+    deferred.reject(new errors.ModelError('batchGet requires keys to be an array'));
     return deferred.promise.nodeify(next);
-  };
+  }
+  options = options || {};
+  if(typeof options === 'function') {
+    next = options;
+    options = {};
+  }
 
-  Model.delete = function(NewModel, key, options, next) {
+  const schema = NewModel.$__.schema;
 
-    const schema = NewModel.$__.schema;
-
-    const hashKeyName = schema.hashKey.name;
+  const hashKeyName = schema.hashKey.name;
+  keys = keys.map(function (key) {
     if(!key[hashKeyName]) {
-      const keyVal = key;
-      key = {};
-      key[hashKeyName] = keyVal;
+      const ret = {};
+      ret[hashKeyName] = key;
+      return ret;
     }
+    return key;
+  });
 
-    if(schema.rangeKey && !key[schema.rangeKey.name]) {
-      const deferred = Q.defer();
-      deferred.reject(new errors.ModelError('Range key required: %s', schema.hashKey.name));
-      return deferred.promise.nodeify(next);
-    }
+  if(schema.rangeKey && !keys.every(function (key) { return validKeyValue(key[schema.rangeKey.name]); })) {
+    deferred.reject(
+      new errors.ModelError('Range key required: ' + schema.rangeKey.name)
+    );
+    return deferred.promise.nodeify(next);
+  }
 
-    const model = new NewModel(key);
-    return model.delete(options, next);
+  const batchReq = {
+    RequestItems: {}
   };
 
-  Model.prototype.delete = function(options, next) {
-    options = options || {};
-    if(typeof options === 'function') {
-      next = options;
-      options = {};
+  const getReq = {};
+  batchReq.RequestItems[NewModel.$__.name] = getReq;
+
+  getReq.Keys = keys.map(function (key) {
+    const ret = {};
+    ret[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName], undefined, key);
+
+    if(schema.rangeKey) {
+      const rangeKeyName = schema.rangeKey.name;
+      ret[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName], undefined, key);
     }
+    return ret;
+  });
 
-    const schema = this.$__.schema;
+  if(options.attributes) {
+    getReq.AttributesToGet = options.attributes;
+  }
 
-    const hashKeyName = schema.hashKey.name;
+  if(options.consistent) {
+    getReq.ConsistentRead = true;
+  }
 
-    const deferred = Q.defer();
+  const newModel$ = NewModel.$__;
 
-    if(this[hashKeyName] === null || this[hashKeyName] === undefined) {
-      deferred.reject(new errors.ModelError('Hash key required: %s', hashKeyName));
-      return deferred.promise.nodeify(next);
-    }
+  function batchGet () {
+    debug('batchGetItem', batchReq);
+    newModel$.base.ddb().batchGetItem(batchReq, function(err, data) {
+      if(err) {
+        debug('Error returned by batchGetItem', err);
+        return deferred.reject(err);
+      }
+      debug('batchGetItem response', data);
 
-    if(schema.rangeKey && (this[schema.rangeKey.name] === null || this[schema.rangeKey.name] === undefined)) {
-        deferred.reject(new errors.ModelError('Range key required: %s', schema.hashKey.name));
-        return deferred.promise.nodeify(next);
+      if(!Object.keys(data).length) {
+        return deferred.resolve();
       }
 
+      function toModel (item) {
+        const model = new NewModel();
+        model.$__.isNew = false;
+        schema.parseDynamo(model, item);
 
-      const getDelete = {
-        TableName: this.$__.name,
-        Key: {}
-      };
+        debug('batchGet parsed model', model);
 
-      try {
-        getDelete.Key[hashKeyName] = schema.hashKey.toDynamo(this[hashKeyName], undefined, this);
-
-        if(schema.rangeKey) {
-          const rangeKeyName = schema.rangeKey.name;
-          getDelete.Key[rangeKeyName] = schema.rangeKey.toDynamo(this[rangeKeyName], undefined, this);
-        }
-      } catch (err) {
-        deferred.reject(err);
-        return deferred.promise.nodeify(next);
+        return model;
       }
 
-      if(options.update) {
-        getDelete.ReturnValues = 'ALL_OLD';
-        getDelete.ConditionExpression = 'attribute_exists(' + schema.hashKey.name + ')';
-      }
-
-      const model = this;
-      const model$ = this.$__;
-
-      function deleteItem() {
-
-        debug('deleteItem', getDelete);
-        model$.base.ddb().deleteItem(getDelete, function(err, data) {
-          if(err) {
-            debug('Error returned by deleteItem', err);
-            return deferred.reject(err);
-          }
-          debug('deleteItem response', data);
-
-          if(options.update && data.Attributes) {
-            try {
-              schema.parseDynamo(model, data.Attributes);
-              debug('deleteItem parsed model', model);
-
-
-            } catch (err) {
-              return deferred.reject(err);
-            }
-          }
-
-          deferred.resolve(model);
-        });
-      }
-
-      if(model$.options.waitForActive) {
-        model$.table.waitForActive().then(deleteItem).catch(deferred.reject);
-      } else {
-        deleteItem();
-      }
-
-      return deferred.promise.nodeify(next);
-
-    };
-
-    /*
-    query(query, options, callback);
-    query(query, options)...exec(callback);
-    query(query, callback);
-    query(query)...exec(callback);
-    query({hash: {id: {eq : 1}}, range: {name: {beginwith: 'foxy'}}})
-    query({id: 1})
-    query('id').eq(1).where('name').begienwith('foxy')
-    */
-    Model.query = function(NewModel, query, options, next) {
-      if(typeof options === 'function') {
-        next = options;
-        options = null;
-      }
-
-      query = new Query(NewModel, query, options);
-
-      if(next) {
-        query.exec(next);
-      }
-
-      return query;
-    };
-
-    Model.queryOne = function(NewModel, query, options, next) {
-      if(typeof options === 'function') {
-        next = options;
-        options = null;
-      }
-
-      query = new Query(NewModel, query, options);
-      query.one();
-
-      if(next) {
-        query.exec(next);
-      }
-
-      return query;
-    };
-
-
-    /*
-
-    scan(filter, options, callback);
-    scan(filter, options)...exec(callback);
-    scan(filter, callback);
-    scan(filter)...exec(callback);
-
-    scan('id').between(a, b).and().where('name').begienwith('foxy').exec();
-
-    scan().exec(); // All records
-
-    */
-    Model.scan = function(NewModel, filter, options, next) {
-      if(typeof options === 'function') {
-        next = options;
-        options = null;
-      }
-
-      const scan = new Scan(NewModel, filter, options);
-
-      if(next) {
-        scan.exec(next);
-      }
-
-      return scan;
-    };
-
-    Model.batchGet = function(NewModel, keys, options, next) {
-      debug('BatchGet %j', keys);
-      const deferred = Q.defer();
-      if(!(keys instanceof Array)) {
-        deferred.reject(new errors.ModelError('batchGet requires keys to be an array'));
-        return deferred.promise.nodeify(next);
-      }
-      options = options || {};
-      if(typeof options === 'function') {
-        next = options;
-        options = {};
-      }
-
-      const schema = NewModel.$__.schema;
-
-      const hashKeyName = schema.hashKey.name;
-      keys = keys.map(function (key) {
-        if(!key[hashKeyName]) {
+      const models = data.Responses[newModel$.name] ? data.Responses[newModel$.name].map(toModel) : [];
+      if (data.UnprocessedKeys[newModel$.name]) {
+        // convert unprocessed keys back to dynamoose format
+        models.unprocessed = data.UnprocessedKeys[newModel$.name].Keys.map(function (key) {
           const ret = {};
-          ret[hashKeyName] = key;
+          ret[hashKeyName] = schema.hashKey.parseDynamo(key[hashKeyName]);
+
+          if(schema.rangeKey) {
+            const rangeKeyName = schema.rangeKey.name;
+            ret[rangeKeyName] = schema.rangeKey.parseDynamo(key[rangeKeyName]);
+          }
           return ret;
-        }
-        return key;
-      });
-
-      if(schema.rangeKey && !keys.every(function (key) { return validKeyValue(key[schema.rangeKey.name]); })) {
-        deferred.reject(
-          new errors.ModelError('Range key required: ' + schema.rangeKey.name)
-        );
-        return deferred.promise.nodeify(next);
-      }
-
-      const batchReq = {
-        RequestItems: {}
-      };
-
-      const getReq = {};
-      batchReq.RequestItems[NewModel.$__.name] = getReq;
-
-      getReq.Keys = keys.map(function (key) {
-        const ret = {};
-        ret[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName], undefined, key);
-
-        if(schema.rangeKey) {
-          const rangeKeyName = schema.rangeKey.name;
-          ret[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName], undefined, key);
-        }
-        return ret;
-      });
-
-      if(options.attributes) {
-        getReq.AttributesToGet = options.attributes;
-      }
-
-      if(options.consistent) {
-        getReq.ConsistentRead = true;
-      }
-
-      const newModel$ = NewModel.$__;
-
-      function batchGet () {
-        debug('batchGetItem', batchReq);
-        newModel$.base.ddb().batchGetItem(batchReq, function(err, data) {
-          if(err) {
-            debug('Error returned by batchGetItem', err);
-            return deferred.reject(err);
-          }
-          debug('batchGetItem response', data);
-
-          if(!Object.keys(data).length) {
-            return deferred.resolve();
-          }
-
-          function toModel (item) {
-            const model = new NewModel();
-            model.$__.isNew = false;
-            schema.parseDynamo(model, item);
-
-            debug('batchGet parsed model', model);
-
-            return model;
-          }
-
-          const models = data.Responses[newModel$.name] ? data.Responses[newModel$.name].map(toModel) : [];
-          if (data.UnprocessedKeys[newModel$.name]) {
-            // convert unprocessed keys back to dynamoose format
-            models.unprocessed = data.UnprocessedKeys[newModel$.name].Keys.map(function (key) {
-              const ret = {};
-              ret[hashKeyName] = schema.hashKey.parseDynamo(key[hashKeyName]);
-
-              if(schema.rangeKey) {
-                const rangeKeyName = schema.rangeKey.name;
-                ret[rangeKeyName] = schema.rangeKey.parseDynamo(key[rangeKeyName]);
-              }
-              return ret;
-            });
-          }
-          deferred.resolve(models);
         });
       }
+      deferred.resolve(models);
+    });
+  }
 
 
-      if(newModel$.options.waitForActive) {
-        newModel$.table.waitForActive().then(batchGet).catch(deferred.reject);
-      } else {
-        batchGet();
-      }
-      return deferred.promise.nodeify(next);
+  if(newModel$.options.waitForActive) {
+    newModel$.table.waitForActive().then(batchGet).catch(deferred.reject);
+  } else {
+    batchGet();
+  }
+  return deferred.promise.nodeify(next);
+};
+
+function toBatchChunks(modelName, list, chunkSize, requestMaker) {
+  const listClone = list.slice(0);
+  let chunk = [];
+  const batchChunks = [];
+
+  while ((chunk = listClone.splice(0, chunkSize)).length) {
+    const requests = chunk.map(requestMaker);
+    const batchReq = {
+      RequestItems: {}
     };
 
-    function toBatchChunks(modelName, list, chunkSize, requestMaker) {
-      const listClone = list.slice(0);
-      let chunk = [];
-      const batchChunks = [];
+    batchReq.RequestItems[modelName] = requests;
+    batchChunks.push(batchReq);
+  }
 
-      while ((chunk = listClone.splice(0, chunkSize)).length) {
-        const requests = chunk.map(requestMaker);
-        const batchReq = {
-          RequestItems: {}
+  return batchChunks;
+}
+
+function reduceBatchResult(resultList) {
+
+  return resultList.reduce(function(acc, res) {
+    const responses = res.Responses ? res.Responses : {};
+    const unprocessed = res.UnprocessedItems ? res.UnprocessedItems : {};
+
+    // merge responses
+    for (const tableName in responses) {
+      if (responses.hasOwnProperty(tableName)) {
+        let consumed = acc.Responses[tableName] ? acc.Responses[tableName].ConsumedCapacityUnits : 0;
+        consumed += responses[tableName].ConsumedCapacityUnits;
+
+        acc.Responses[tableName] = {
+          ConsumedCapacityUnits: consumed
         };
-
-        batchReq.RequestItems[modelName] = requests;
-        batchChunks.push(batchReq);
       }
-
-      return batchChunks;
     }
 
-    function reduceBatchResult(resultList) {
-
-      return resultList.reduce(function(acc, res) {
-        const responses = res.Responses ? res.Responses : {};
-        const unprocessed = res.UnprocessedItems ? res.UnprocessedItems : {};
-
-        // merge responses
-        for (const tableName in responses) {
-          if (responses.hasOwnProperty(tableName)) {
-            let consumed = acc.Responses[tableName] ? acc.Responses[tableName].ConsumedCapacityUnits : 0;
-            consumed += responses[tableName].ConsumedCapacityUnits;
-
-            acc.Responses[tableName] = {
-              ConsumedCapacityUnits: consumed
-            };
-          }
-        }
-
-        // merge unprocessed items
-        for (const tableName2 in unprocessed) {
-          if (unprocessed.hasOwnProperty(tableName2)) {
-            const items = acc.UnprocessedItems[tableName2] ? acc.UnprocessedItems[tableName2] : [];
-            items.push(unprocessed[tableName2]);
-            acc.UnprocessedItems[tableName2] = items;
-          }
-        }
-
-        return acc;
-      }, {Responses: {}, UnprocessedItems: {}});
+    // merge unprocessed items
+    for (const tableName2 in unprocessed) {
+      if (unprocessed.hasOwnProperty(tableName2)) {
+        const items = acc.UnprocessedItems[tableName2] ? acc.UnprocessedItems[tableName2] : [];
+        items.push(unprocessed[tableName2]);
+        acc.UnprocessedItems[tableName2] = items;
+      }
     }
 
-    function batchWriteItems (NewModel, batchRequests) {
-      debug('batchWriteItems');
-      const newModel$ = NewModel.$__;
+    return acc;
+  }, {Responses: {}, UnprocessedItems: {}});
+}
 
-      const batchList = batchRequests.map(function (batchReq) {
-        const deferredBatch = Q.defer();
+function batchWriteItems (NewModel, batchRequests) {
+  debug('batchWriteItems');
+  const newModel$ = NewModel.$__;
 
-        newModel$.base.ddb().batchWriteItem(batchReq, function(err, data) {
-          if(err) {
-            debug('Error returned by batchWriteItems', err);
-            return deferredBatch.reject(err);
-          }
+  const batchList = batchRequests.map(function (batchReq) {
+    const deferredBatch = Q.defer();
 
-          deferredBatch.resolve(data);
-        });
-
-        return deferredBatch.promise;
-      });
-
-      return Q.all(batchList).then(function (resultList) {
-        return reduceBatchResult(resultList);
-      });
-    }
-
-    Model.batchPut = function(NewModel, items, options, next) {
-      debug('BatchPut %j', items);
-      const deferred = Q.defer();
-
-      if(!(items instanceof Array)) {
-        deferred.reject(new errors.ModelError('batchPut requires items to be an array'));
-        return deferred.promise.nodeify(next);
-      }
-      options = options || {};
-      if(typeof options === 'function') {
-        next = options;
-        options = {};
+    newModel$.base.ddb().batchWriteItem(batchReq, function(err, data) {
+      if(err) {
+        debug('Error returned by batchWriteItems', err);
+        return deferredBatch.reject(err);
       }
 
-      const schema = NewModel.$__.schema;
-      const newModel$ = NewModel.$__;
+      deferredBatch.resolve(data);
+    });
 
-      const batchRequests = toBatchChunks(newModel$.name, items, MAX_BATCH_WRITE_SIZE, function(item) {
-        return {
-          PutRequest: {
-            Item: schema.toDynamo(item)
-          }
-        };
-      });
+    return deferredBatch.promise;
+  });
 
-      const batchPut = function() {
-        batchWriteItems(NewModel, batchRequests).then(function (result) {
-          deferred.resolve(result);
-        }).fail(function (err) {
-          deferred.reject(err);
-        });
-      };
+  return Q.all(batchList).then(function (resultList) {
+    return reduceBatchResult(resultList);
+  });
+}
 
-      if(newModel$.options.waitForActive) {
-        newModel$.table.waitForActive().then(batchPut).catch(deferred.reject);
-      } else {
-        batchPut();
+Model.batchPut = function(NewModel, items, options, next) {
+  debug('BatchPut %j', items);
+  const deferred = Q.defer();
+
+  if(!(items instanceof Array)) {
+    deferred.reject(new errors.ModelError('batchPut requires items to be an array'));
+    return deferred.promise.nodeify(next);
+  }
+  options = options || {};
+  if(typeof options === 'function') {
+    next = options;
+    options = {};
+  }
+
+  const schema = NewModel.$__.schema;
+  const newModel$ = NewModel.$__;
+
+  const batchRequests = toBatchChunks(newModel$.name, items, MAX_BATCH_WRITE_SIZE, function(item) {
+    return {
+      PutRequest: {
+        Item: schema.toDynamo(item)
       }
-      return deferred.promise.nodeify(next);
     };
+  });
 
-    Model.batchDelete = function(NewModel, keys, options, next) {
-      debug('BatchDel %j', keys);
-      const deferred = Q.defer();
+  const batchPut = function() {
+    batchWriteItems(NewModel, batchRequests).then(function (result) {
+      deferred.resolve(result);
+    }).fail(function (err) {
+      deferred.reject(err);
+    });
+  };
 
-      if(!(keys instanceof Array)) {
-        deferred.reject(new errors.ModelError('batchDelete requires keys to be an array'));
-        return deferred.promise.nodeify(next);
+  if(newModel$.options.waitForActive) {
+    newModel$.table.waitForActive().then(batchPut).catch(deferred.reject);
+  } else {
+    batchPut();
+  }
+  return deferred.promise.nodeify(next);
+};
+
+Model.batchDelete = function(NewModel, keys, options, next) {
+  debug('BatchDel %j', keys);
+  const deferred = Q.defer();
+
+  if(!(keys instanceof Array)) {
+    deferred.reject(new errors.ModelError('batchDelete requires keys to be an array'));
+    return deferred.promise.nodeify(next);
+  }
+
+  options = options || {};
+  if(typeof options === 'function') {
+    next = options;
+    options = {};
+  }
+
+  const schema = NewModel.$__.schema;
+  const newModel$ = NewModel.$__;
+  const hashKeyName = schema.hashKey.name;
+
+  const batchRequests = toBatchChunks(newModel$.name, keys, MAX_BATCH_WRITE_SIZE, function(key) {
+    const key_element = {};
+    key_element[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]), undefined, key;
+
+    if(schema.rangeKey) {
+      key_element[schema.rangeKey.name] = schema.rangeKey.toDynamo(key[schema.rangeKey.name], undefined, key);
+    }
+
+    return {
+      DeleteRequest: {
+        Key: key_element
       }
-
-      options = options || {};
-      if(typeof options === 'function') {
-        next = options;
-        options = {};
-      }
-
-      const schema = NewModel.$__.schema;
-      const newModel$ = NewModel.$__;
-      const hashKeyName = schema.hashKey.name;
-
-      const batchRequests = toBatchChunks(newModel$.name, keys, MAX_BATCH_WRITE_SIZE, function(key) {
-        const key_element = {};
-        key_element[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName]), undefined, key;
-
-        if(schema.rangeKey) {
-          key_element[schema.rangeKey.name] = schema.rangeKey.toDynamo(key[schema.rangeKey.name], undefined, key);
-        }
-
-        return {
-          DeleteRequest: {
-            Key: key_element
-          }
-        };
-      });
-
-      const batchDelete = function() {
-        batchWriteItems(NewModel, batchRequests).then(function (result) {
-          deferred.resolve(result);
-        }).fail(function (err) {
-          deferred.reject(err);
-        });
-      };
-
-      if(newModel$.options.waitForActive) {
-        newModel$.table.waitForActive().then(batchDelete).catch(deferred.reject);
-      } else {
-        batchDelete();
-      }
-      return deferred.promise.nodeify(next);
     };
+  });
 
-    module.exports = Model;
+  const batchDelete = function() {
+    batchWriteItems(NewModel, batchRequests).then(function (result) {
+      deferred.resolve(result);
+    }).fail(function (err) {
+      deferred.reject(err);
+    });
+  };
+
+  if(newModel$.options.waitForActive) {
+    newModel$.table.waitForActive().then(batchDelete).catch(deferred.reject);
+  } else {
+    batchDelete();
+  }
+  return deferred.promise.nodeify(next);
+};
+
+module.exports = Model;


### PR DESCRIPTION
### Summary:

Removing `self = this` in favor of arrow functions.


### Type (select 1):
- [ ] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [x] Something not listed here: Codebase improvements


### Is this a breaking change? (select 1):
- [x] 🚨 YES 🚨: Acceptable because Dynamoose now requires a higher Node.js version
- [ ] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [ ] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [ ] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have run `npm test` from the root of the project directory to ensure all tests continue to pass
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have confirmed that all my code changes are indented properly using 2 spaces
- [x] I have filled out all fields above
