### PR TITLE
Using Buffer.from instead of new Buffer

### DIFF
--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -525,7 +525,7 @@ Attribute.prototype.parseDynamo = function(json) {
     return new Date(parseInt(v, 10));
   }
   function bufferify(v) {
-    return new Buffer(v);
+    return Buffer.from(v);
   }
   function stringify(v){
     if (typeof v !== 'string'){


### PR DESCRIPTION
### Summary:

Using `Buffer.from` instead of `new Buffer` due to new Node.js DeprecationWarning.


### Type (select 1):
- [ ] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [x] Something not listed here: Codebase improvements


### Is this a breaking change? (select 1):
- [x] 🚨 YES 🚨: Acceptable due to Dynamoose requiring new Node.js versions
- [ ] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have run `npm test` from the root of the project directory to ensure all tests continue to pass
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have confirmed that all my code changes are indented properly using 2 spaces
- [x] I have filled out all fields above
