### PR TITLE
Change QueryKey and ScanKey type to any

### DIFF
--- a/dynamoose.d.ts
+++ b/dynamoose.d.ts
@@ -252,7 +252,7 @@ declare module "dynamoose" {
   export interface QueryResult<T> extends Array<T> {
     lastKey?: QueryKey;
   }
-  type QueryKey = string;
+  type QueryKey = any;
 
 
   /**
@@ -292,7 +292,7 @@ declare module "dynamoose" {
     lastKey?: ScanKey;
   }
 
-  type ScanKey = string;
+  type ScanKey = any;
 
   export class VirtualType {
     constructor(options: any, name: string);


### PR DESCRIPTION
The method startAt requires an object with the same format as the one given by the lastKey value not a String

### Summary:
The type definition is incorrect for the types QueryKey and ScanKey since these two types are used for the startAt function.

The startAt key expects an object with the same format as the one given by the lastKey field when executing a query or scan and currently it was asking for a String which is causing a problem when trying to send the value.

There was a workaround for this using:

```
myquery.startAt({ id: { S: "someid" } } as any).exec();
```

But that's just not OK.


### Code sample:
This should work now:

```
myquery.startAt({ id: { S: "someid" } }).exec();
```


### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have run `npm test` from the root of the project directory to ensure all tests continue to pass
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have confirmed that all my code changes are indented properly using 2 spaces
- [x] I have filled out all fields above
