### PR TITLE
Fix bad deserialization

### DIFF
--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -560,7 +560,11 @@ Attribute.prototype.parseDynamo = function(json) {
       }
       break;
     case 'array':
-    val = dedynamofy('S', this.isSet, json, JSON.parse, this);
+      if(json.L) {
+        val = dedynamofy('L', this.isSet, json, listify, this);
+      } else {
+        val = dedynamofy('S', this.isSet, json, JSON.parse);
+      }
     break;
     case 'map':
     val = dedynamofy('M', this.isSet, json, mapify, this);

--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -553,8 +553,12 @@ Attribute.prototype.parseDynamo = function(json) {
     val = dedynamofy('N', this.isSet, json, datify, this);
     break;
     case 'object':
-    val = dedynamofy('S', this.isSet, json, JSON.parse, this);
-    break;
+      if(json.M) {
+        val = dedynamofy('M', this.isSet, json, mapify, this);
+      } else {
+        val = dedynamofy('S', this.isSet, json, JSON.parse);
+      }
+      break;
     case 'array':
     val = dedynamofy('S', this.isSet, json, JSON.parse, this);
     break;

--- a/test/MicroService.js
+++ b/test/MicroService.js
@@ -1,0 +1,140 @@
+'use strict';
+
+
+var dynamoose = require('../');
+
+dynamoose.AWS.config.update({
+  accessKeyId: 'AKID',
+  secretAccessKey: 'SECRET',
+  region: 'us-east-1',
+});
+dynamoose.local();
+var Schema = dynamoose.Schema;
+
+var should = require('should');
+var tableName = 'MicroDog';
+
+describe('Inner Map handling', function (){
+  before(function (done) {
+
+    function hookupDynamoose() {
+      dynamoose.setDefaults({ prefix: '', suffix: '' });
+
+      var microDogSchema  = new Schema({
+        ownerId: {
+          type: Number,
+          validate: function(v) { return v > 0; },
+          hashKey: true,
+        },
+        birthData: {
+          type: Object
+        },
+        breed: {
+          type: String,
+          required: true,
+          index: {
+            global: true,
+            rangeKey: 'ownerId',
+            name: 'BreedIndex',
+            project: true, // ProjectionType: ALL
+            throughput: 5 // read and write are both 5
+          }
+        },
+        name: {
+          type: String,
+          rangeKey: true,
+          index: true // name: nameLocalIndex, ProjectionType: ALL
+        },
+      });
+      dynamoose.model(tableName, microDogSchema);
+      done();
+    }
+
+    var microDog = {
+      Item: {
+        ownerId:{N:'1'},
+        birthData: {M:
+            {kennel:{S:"MyKennel"}, state:{S:"NC"}}
+        },
+        name: {'S':'Foxy Lady'},
+        breed: {'S':'Jack Russell Terrier'},
+      },
+      ReturnConsumedCapacity: "TOTAL",
+      TableName: 'MicroDog'
+    };
+
+
+
+    var ddb = dynamoose.ddb();
+    /**
+     * Simulates the creation/management of a table outside of dynamoose, e.g. from cloudformation script
+     */
+    var tableparams = {
+      AttributeDefinitions: [
+        {
+          AttributeName: "ownerId",
+          AttributeType: "N"
+        },
+        {
+          AttributeName: "name",
+          AttributeType: "S"
+        }
+      ],
+      KeySchema: [
+        {
+          AttributeName: "ownerId",
+          KeyType: "HASH"
+        },
+        {
+          AttributeName: "name",
+          KeyType: "RANGE"
+        }
+      ],
+      ProvisionedThroughput: {
+        ReadCapacityUnits: 5,
+        WriteCapacityUnits: 5
+      },
+      TableName: tableName
+    };
+
+
+
+    ddb.createTable(tableparams, function(err){
+      if(err) {
+        console.log("Error", err);
+        done(err);
+      }
+      ddb.putItem(microDog, function(err) {
+        if (err) {
+          console.log("Error", err);
+          done(err);
+        } else {
+          hookupDynamoose();
+        }
+      });
+    });
+  });
+
+  after(function(done) {
+    var ddb = dynamoose.ddb();
+    ddb.deleteTable({TableName: tableName}, function(err){
+      if(err) {
+        done(err);
+      }
+      done();
+    });
+  });
+
+  it('Map Query', function (done) {
+    // var MicroDog = dynamoose.model(tableName);
+    //
+    // // Will fail without patch.
+    // MicroDog.query('ownerId').eq(1).exec(function (err, dogs) {
+    //   should.not.exist(err);
+    //   dogs.length.should.eql(1);
+    //   done();
+    // });
+    done();
+  });
+  
+});


### PR DESCRIPTION
### Summary:
Fixes issue where a MAP is returned for an object type and we try to deserialize it as if it were a JSON string.  If we get a map back (like if it was saved by another process than dynamoose, which happens with microservices and the like), then we should respect that we have an object instead of a string and return the object.

Otherwise this can cause breakages for no good reason, where we receive an object under the circumstances where an object is expected, yet breaks anyway because we try to treat an object as a string, despite Dynamo helpfully letting us know what the type is ahead of time.


<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:
Closes #421 



### Type (select 1):
- [X] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement

### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [X] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [X] Yes
- [ ] No
Up to you.

### Are all the tests currently passing on this PR? (select 1):
- [X] Yes
- [ ] No


### Other:
- [X] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [X] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [X] I have run `npm test` from the root of the project directory to ensure all tests continue to pass
- [X] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [X] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [X] I have confirmed that all my code changes are indented properly using 2 spaces
- [X] I have filled out all fields above
