### PR TITLE
Fixing typo related to stream options

### DIFF
--- a/lib/Table.js
+++ b/lib/Table.js
@@ -494,7 +494,7 @@ const buildTableReq = Table.prototype.buildTableReq = function buildTableReq(nam
   }
 
   if (this && this.options) {
-    if (this.options.steamOptions && this.options.steamOptions.enabled === true) {
+    if (this.options.streamOptions && this.options.streamOptions.enabled === true) {
       createTableReq.StreamSpecification = {
         StreamEnabled: true,
         StreamViewType: this.options.streamOptions.type


### PR DESCRIPTION
### Summary:

This PR fixes an typo where `streamOptions` was accidentally spelled `steamOptions`.


### GitHub linked issue:
Closes #430 


### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have run `npm test` from the root of the project directory to ensure all tests continue to pass
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have confirmed that all my code changes are indented properly using 2 spaces
- [x] I have filled out all fields above
