### PR TITLE
Allow querying local indexes and resolve problem with using updatedAt as range key in a query.

### DIFF
--- a/lib/Query.js
+++ b/lib/Query.js
@@ -88,10 +88,10 @@ Query.prototype.exec = function (next) {
   // the hash and range key on the primary table.  If they don't match then we
   // can look for a secondary index to query.
   if(schema.hashKey.name !== this.query.hashKey.name || (this.query.rangeKey && schema.rangeKey && schema.rangeKey.name !== this.query.rangeKey.name)) {
-    debug('query is on global secondary index');
     for(indexName in schema.indexes.global) {
       index = schema.indexes.global[indexName];
       if(index.name === this.query.hashKey.name && (!this.query.rangeKey || index.indexes[indexName].rangeKey === this.query.rangeKey.name)) {
+        debug('query is on global secondary index');
         debug('using index', indexName);
         queryReq.IndexName = indexName;
         break;
@@ -116,7 +116,7 @@ Query.prototype.exec = function (next) {
       debug('query is on local secondary index');
       for(indexName in schema.indexes.local) {
         index = schema.indexes.local[indexName];
-        if(index.name === rangeKey.name && index.indexes[indexName].rangeKey === this.query.rangeKey.name) {
+        if(index.name === rangeKey.name) {
           debug('using local index', indexName);
           queryReq.IndexName = indexName;
           break;

--- a/lib/Query.js
+++ b/lib/Query.js
@@ -135,7 +135,7 @@ Query.prototype.exec = function (next) {
       for (i = 0; i < rangeKey.values.length; i++) {
         val = rangeKey.values [i];
         keyConditions.AttributeValueList.push(
-          rangeAttr.toDynamo(val, true)
+          rangeAttr.toDynamo(val, true, Model, { updateTimestamps: false })
         );
       }
     }

--- a/test/Query.js
+++ b/test/Query.js
@@ -678,56 +678,50 @@ describe('Query', function (){
   	});
   });
 
-  it('Should allow multiple local indexes and query correctly', function (done) {
+  it('Should allow multiple local indexes and query correctly', async function () {
     var schema = new dynamoose.Schema({
       id: {
         type: String,
         hashKey: true,
-        required: true
       },
       orgId: {
         type: String,
-        index: [{
-          global    : false,
-          name      : 'OrganizationCreateAtIndex',
-          rangeKey  : 'createdAt',
-          throughput: 1
-      }, {
-          global    : false,
-          name      : 'OrganizationExpectedArriveAtIndex',
-          rangeKey  : 'expectedArriveAt',
-          throughput: 1
-      }],
-      required: true,
+        rangeKey: true,
       },
-      expectedArriveAt: Date
+      updatedAt: {
+        type: Date,
+        index: {
+          global: false,
+          name  : 'OrganizationUpdatedAtIndex'
+        }
+      },
+      expectedArriveAt: {
+        type: Date,
+        index: {
+          global: false,
+          name  : 'OrganizationExpectedArriveAtIndex'
+        }
+      }
     },{
       throughput: 1,
       timestamps: true
     });
-    var Log = dynamoose.model('Log-1', schema);
+    var Log = dynamoose.model('Log-2', schema);
 
     var log1 = new Log({id: "test1", orgId: "org1", expectedArriveAt: Date.now()});
-    log1.save(function() {
-      Log.query('orgId').eq("org1")
+    var log2 = new Log({id: "test1", orgId: "org2", expectedArriveAt: Date.now()});
+
+    await log1.save();
+    await log2.save();
+
+    var res = await Log.query('id').eq("test1")
       .where('expectedArriveAt').lt( new Date() )
       .exec()
-      .then(function(res){
-        res.length.should.eql(1);
-        Log.query('orgId').eq("org1")
-        .where('createdAt').lt( new Date() )
-        .exec()
-        .then(function(res){
-          res.length.should.eql(1);
-          done();
-        })
-        .catch(function(e){
-          done(e);
-        });
-      })
-      .catch(function(e){
-        done(e);
-      });
-    });
+    res.length.should.eql(2);
+    
+    var res2 = await Log.query('id').eq("test1")
+      .where('updatedAt').le( log1.createdAt.getTime() )
+      .exec();
+    res2.length.should.eql(1);
   });
 });

--- a/test/Query.js
+++ b/test/Query.js
@@ -50,6 +50,10 @@ describe('Query', function (){
           throughput: 5 // read and write are both 5
         }
       },
+      origin: {
+        type: String,
+        index: true // name: originLocalIndex, ProjectionType: ALL
+      },
       name: {
         type: String,
         rangeKey: true,
@@ -112,10 +116,10 @@ describe('Query', function (){
       {ownerId:17, name: 'Beethoven', breed: 'St. Bernard', age: 3},
       {ownerId:18, name: 'Lassie', breed: 'Collie', color: 'tan and white', age: 4},
       {ownerId:19, name: 'Snoopy', breed: 'beagle', color: 'black and white', age: 6},
-      {ownerId:20, name: 'Max', breed: 'Westie', age: 7},
-      {ownerId:20, name: 'Gigi', breed: 'Spaniel', color: 'Chocolate', age: 1},
-      {ownerId:20, name: 'Mimo', breed: 'Boxer', color: 'Chocolate', age: 2},
-      {ownerId:20, name: 'Bepo', breed: 'French Bulldog', color: 'Grey', age: 4},
+      {ownerId:20, name: 'Max', breed: 'Westie', age: 7, origin: 'Scotland'},
+      {ownerId:20, name: 'Gigi', breed: 'Spaniel', color: 'Chocolate', age: 1, origin: 'Great Britain'},
+      {ownerId:20, name: 'Mimo', breed: 'Boxer', color: 'Chocolate', age: 2,  origin: 'Germany'},
+      {ownerId:20, name: 'Bepo', breed: 'French Bulldog', color: 'Grey', age: 4, origin: 'France'},
     ]);
 
   });
@@ -209,10 +213,10 @@ describe('Query', function (){
     });
   });
 
-  it('Query with Local Global Index as range', function (done) {
+  it('Query with Secondary Local Index as range', function (done) {
     var Dog = dynamoose.model('Dog');
 
-    Dog.query('ownerId').eq(2).where('color').beginsWith('White').exec(function (err, dogs) {
+    Dog.query('ownerId').eq(20).where('origin').beginsWith('G').exec(function (err, dogs) {
       should.not.exist(err);
       dogs.length.should.eql(2);
       done();


### PR DESCRIPTION
<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->


### Summary:

This PR fixes the issue discussed in #439, and one more bug:
`toDynamo` method of Attribute is called without `updateTimestamps` option set to `false` during `Query.exec()`, so when `updatedAt` timestamp is used as a range key in a query, supplied value gets substituted with current timestamp.

I also moved the debug statement for global secondary index, because local secondary index passes that outer check too.

<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->
Closes #439 


<!-- Please remove the `Other information` section below if it doesn't apply to this PR -->
### Other information:

I took the liberty of updating existing tests that were doing nothing meaningful instead of creating new ones. Let me know if you want me to resort to a more conservative option and just define my own tests. However, please note that test `Query with Local Global Index as range` (I assumed there's a typo in the name) currently queries a global index, not a local one, while test `Should allow multiple local indexes and query correctly` in its current state should fail as it doesn't even make sense conceptually (local indexes can't have their own range keys and it doesn't make sense for the same attribute to be the key of multiple local indexes). Moreover, the schema defined in that test most likely ends up being unused (which might be why it doesn't fail), because instead of creating a new table it tries to overwrite the one created by the previous test (`Log-1`) and likely fails silently, because you cannot add / remove local indexes for an existing table, you have to create a new one.

I marked this as a breaking change, however, if we assume that no one used the fact that updatedAt value was changed during a query as a "feature", it shouldn't break any code.

### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [x] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [x] 🚨 YES 🚨
- [ ] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [ ] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have run `npm test` from the root of the project directory to ensure all tests continue to pass
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have confirmed that all my code changes are indented properly using 2 spaces
- [x] I have filled out all fields above
