### PR TITLE
Raise error if list or map not provided

### DIFF
--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -56,10 +56,11 @@ function Attribute(schema, name, value) {
   else if (this.type.name === 'list'){
 
     if(value.type) {
+      if (!value.list) throw new errors.SchemaError('No list schema provided for attribute:' + this.name );
       value = value.list;
     }
 
-    if (value === undefined && value[0] === undefined){
+    if (value === undefined || value[0] === undefined){
       throw new errors.SchemaError('No object given for attribute:' + this.name );
     }
     // stang: Don't know what this guard is for - had to remove because when parsing unknown attributes, this is legal?

--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -42,6 +42,9 @@ function Attribute(schema, name, value) {
   if (this.type.name === 'map'){
 
     if(value.type) {
+      if (!value.map) {
+        throw new errors.SchemaError('No map schema given for attribute:' + this.name );
+      }
       value = value.map;
     }
     for (const subattrName in value){
@@ -56,13 +59,12 @@ function Attribute(schema, name, value) {
   else if (this.type.name === 'list'){
 
     if(value.type) {
-      if (!value.list) throw new errors.SchemaError('No list schema provided for attribute:' + this.name );
+      if (value.list === undefined || value.list[0] === undefined){
+        throw new errors.SchemaError('No list schema given for attribute:' + this.name );
+      }
       value = value.list;
     }
 
-    if (value === undefined || value[0] === undefined){
-      throw new errors.SchemaError('No object given for attribute:' + this.name );
-    }
     // stang: Don't know what this guard is for - had to remove because when parsing unknown attributes, this is legal?
     // if (value.length > 1){
     //   throw new errors.SchemaError('Only one object can be defined as a list type in ' + this.name );

--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -43,7 +43,7 @@ function Attribute(schema, name, value) {
 
     if(value.type) {
       if (!value.map) {
-        throw new errors.SchemaError('No map schema given for attribute:' + this.name );
+        throw new errors.SchemaError(`No map schema given for attribute: ${this.name}`);
       }
       value = value.map;
     }
@@ -59,8 +59,8 @@ function Attribute(schema, name, value) {
   else if (this.type.name === 'list'){
 
     if(value.type) {
-      if (value.list === undefined || value.list[0] === undefined){
-        throw new errors.SchemaError('No list schema given for attribute:' + this.name );
+      if (!value.list || !value.list[0]){
+        throw new errors.SchemaError(`No list schema given for attribute: ${this.name}`);
       }
       value = value.list;
     }

--- a/test/Schema.js
+++ b/test/Schema.js
@@ -1192,31 +1192,37 @@ describe('Schema tests', function (){
   });
 
   it('Should throw error when type is map but no map is provided', function (done) {
+    let err;
     try {
       var schema = new Schema({
         race: {
           type: 'map',
         }
       });
-    } catch (err) {
-      err.should.be.instanceof(Error);
-      err.should.be.instanceof(errors.SchemaError);
+    } catch (e) {
+      err = e;
     }
+    err.should.be.instanceof(Error);
+    err.should.be.instanceof(errors.SchemaError);
+
     done();
   });
 
   it('Should throw error when type is list but no list is provided', function (done) {
+    let err;
     try {
       var schema = new Schema({
         race: {
           type: 'list',
         }
       });
-    } catch (err) {
-      err.should.be.instanceof(Error);
-      err.should.be.instanceof(errors.SchemaError);
+    } catch (e) {
+      err = e;
     }
+    err.should.be.instanceof(Error);
+    err.should.be.instanceof(errors.SchemaError);
 
+    err = undefined;
     try {
       var schema = new Schema({
         race: {
@@ -1224,10 +1230,12 @@ describe('Schema tests', function (){
           list: []
         }
       });
-    } catch (err) {
-      err.should.be.instanceof(Error);
-      err.should.be.instanceof(errors.SchemaError);
+    } catch (e) {
+      err = e
     }
+
+    err.should.be.instanceof(Error);
+    err.should.be.instanceof(errors.SchemaError);
 
     done();
 

--- a/test/Schema.js
+++ b/test/Schema.js
@@ -1190,4 +1190,33 @@ describe('Schema tests', function (){
     });
     done();
   });
+
+  it('Should throw error when type is map but no map is provided', function (done) {
+    try {
+      var schema = new Schema({
+        race: {
+          type: 'map',
+        }
+      });
+    } catch (err) {
+      err.should.be.instanceof(Error);
+      err.should.be.instanceof(errors.SchemaError);
+    }
+    done();
+  });
+
+  it('Should throw error when type is list but no list is provided', function (done) {
+    try {
+      var schema = new Schema({
+        race: {
+          type: 'list',
+        }
+      });
+    } catch (err) {
+      err.should.be.instanceof(Error);
+      err.should.be.instanceof(errors.SchemaError);
+    }
+    done();
+
+  });
 });

--- a/test/Schema.js
+++ b/test/Schema.js
@@ -1216,6 +1216,19 @@ describe('Schema tests', function (){
       err.should.be.instanceof(Error);
       err.should.be.instanceof(errors.SchemaError);
     }
+
+    try {
+      var schema = new Schema({
+        race: {
+          type: 'list',
+          list: []
+        }
+      });
+    } catch (err) {
+      err.should.be.instanceof(Error);
+      err.should.be.instanceof(errors.SchemaError);
+    }
+
     done();
 
   });


### PR DESCRIPTION
It seems to me that the existing conditional `(value === undefined && value[0] === undefined)` errors if value is indeed undefined. This change fixes that and adds a more descriptive error if the user forgets to provide the `list` key when using `type: 'list'`.

<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->


### Summary:




<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:
#### Schema
```
// Code here
```

#### Model
```
// Code here
```

#### General
```
// Code here
```


<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->
#---


<!-- Please remove the `Other information` section below if it doesn't apply to this PR -->
### Other information:




### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [ ] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [ ] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [ ] I have run `npm test` from the root of the project directory to ensure all tests continue to pass
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have confirmed that all my code changes are indented properly using 2 spaces
- [ ] I have filled out all fields above
