### PR TITLE
Adding expires defaultExpires function

### DIFF
--- a/docs/_docs/schema.md
+++ b/docs/_docs/schema.md
@@ -244,9 +244,9 @@ var schema = new Schema({...}, {
 });
 ```
 
-**expires**: number &#124; {ttl: number, attribute: string, returnExpiredItems: boolean}
+**expires**: number &#124; {ttl: number, attribute: string, returnExpiredItems: boolean, defaultExpires: function}
 
-Defines that _schema_ must contain and expires attribute.  This field is configured in DynamoDB as the TTL attribute.  If set to a `number`, an attribute named "expires" will be added to the schema.  The default value of the attribute will be the current time plus the expires value.  The expires value is in seconds.
+Defines that _schema_ must contain an expires attribute.  This field is configured in DynamoDB as the TTL attribute.  If set to a `number`, an attribute named "expires" will be added to the schema.  The default value of the attribute will be the current time plus the expires value, unless an optional defaultExpires property is passed in.  The expires value is in seconds.
 
 The attribute will be a standard javascript `Date` in the object, and will be stored as number ('N') in the DyanmoDB table. The stored number is in seconds.  [More information about DynamoDB TTL](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html)
 
@@ -263,7 +263,10 @@ var schema = new Schema({...}, {
   expires: {
     ttl: 7*24*60*60, // 1 week in seconds
     attribute: 'ttl', // ttl will be used as the attribute name
-    returnExpiredItems: true // if expired items will be returned or not (default: true)
+    returnExpiredItems: true, // if expired items will be returned or not (default: true)
+    defaultExpires: function () { // optional, will default to `ttl` if not defined, this function is mainly used to allow the expires to be set to null or undefined, without resetting to the normal default
+      return null;
+    }
   }
 });
 ```

--- a/lib/Schema.js
+++ b/lib/Schema.js
@@ -77,7 +77,6 @@ function Schema(obj, options) {
 
     if (typeof this.options.expires === 'number') {
       expires.ttl = this.options.expires;
-
     } else if (typeof this.options.expires === 'object') {
       if (typeof this.options.expires.ttl === 'number') {
         expires.ttl = this.options.expires.ttl;
@@ -91,6 +90,10 @@ function Schema(obj, options) {
       if (typeof this.options.expires.returnExpiredItems === "boolean") {
         expires.returnExpiredItems = this.options.expires.returnExpiredItems;
       }
+
+      if (typeof this.options.expires.defaultExpires === "function") {
+        expires.defaultExpires = this.options.expires.defaultExpires;
+      }
     } else {
       throw new errors.SchemaError('Invalid syntax for expires: ' + this.options.expires);
     }
@@ -101,7 +104,7 @@ function Schema(obj, options) {
 
     obj[expires.attribute] = {
       type: Number,
-      default: defaultExpires,
+      default: expires.defaultExpires || defaultExpires,
       set: function(v) {
         return Math.floor(v.getTime() / 1000);
       },

--- a/test/Model.js
+++ b/test/Model.js
@@ -1180,7 +1180,7 @@ describe('Model', function (){
                   should.exist(fluffy);
                   should.exist(fluffy.expires);
                   should.exist(fluffy.expires.getTime);
-                  
+
                   var expiresInSec2 = Math.floor(fluffy.expires.getTime() / 1000);
                   expiresInSec2.should.be.above(expiresInSec);
 
@@ -1252,9 +1252,24 @@ describe('Model', function (){
 
           });
 
+          it('Should not have an expires property if TTL is set to null', function (done) {
+            Cats.ExpiringCatNull.create({
+              name: 'Leo12'
+            })
+            .then(function () {
+              Cats.ExpiringCatNull.get("Leo12").then(function (leo) {
+                should.exist(leo);
+                should.not.exist(leo.expires);
+                done();
+              }).catch(done);
+            })
+            .catch(done);
+          });
+
           it('Should not return expired items if returnExpiredItems is false (get)', function (done) {
             Cats.ExpiringCatNoReturn.create({
-              name: 'Leo1'
+              name: 'Leo1',
+              expires: new Date(new Date().getTime() + (1000 * 60 * 60 * 24 * 365))
             })
             .then(function (leo) {
               leo.expires = new Date(Date.now() - 5000);
@@ -1269,16 +1284,55 @@ describe('Model', function (){
             .catch(done);
           });
 
+          it('Should return expired items if returnExpiredItems is false and expires is null (get)', function (done) {
+            Cats.ExpiringCatNoReturn.create({
+              name: 'Leo11',
+              expires: new Date(new Date().getTime() + (1000 * 60 * 60 * 24 * 365))
+            })
+            .then(function (leo) {
+              leo.expires = null;
+              return leo.save();
+            })
+            .then(function () {
+              Cats.ExpiringCatNoReturn.get("Leo11").then(function (leo) {
+                should.not.exist(leo.expires);
+                should.exist(leo);
+                done();
+              }).catch(done);
+            })
+            .catch(done);
+          });
+
           it('Should return expired items if returnExpiredItems is undefined (get)', function (done) {
-            Cats.ExpiringCat.create({
-              name: 'Leo1'
+            Cats.ExpiringCatNull.create({
+              name: 'Leo1',
+              expires: new Date(new Date().getTime() + (1000 * 60 * 60 * 24 * 365))
             })
             .then(function (leo) {
               leo.expires = new Date(Date.now() - 5000);
               return leo.save();
             })
             .then(function () {
-              Cats.ExpiringCat.get("Leo1").then(function (leo) {
+              Cats.ExpiringCatNull.get("Leo1").then(function (leo) {
+                should.exist(leo);
+                done();
+              }).catch(done);
+            })
+            .catch(done);
+          });
+
+          it('Should return expired items if returnExpiredItems is undefined and expires is null (get)', function (done) {
+            Cats.ExpiringCatNull.create({
+              name: 'Leo11',
+              expires: new Date(new Date().getTime() + (1000 * 60 * 60 * 24 * 365))
+            })
+            .then(function (leo) {
+              leo.expires = null;
+              return leo.save();
+            })
+            .then(function () {
+              Cats.ExpiringCatNull.get("Leo11").then(function (leo) {
+                should.not.exist(leo.expires);
                 should.exist(leo);
                 done();
               }).catch(done);
@@ -1288,7 +1342,8 @@ describe('Model', function (){
 
           it('Should return expired items if returnExpiredItems is true (get)', function (done) {
             Cats.ExpiringCatReturnTrue.create({
-              name: 'Leo1'
+              name: 'Leo1',
+              expires: new Date(new Date().getTime() + (1000 * 60 * 60 * 24 * 365))
             })
             .then(function (leo) {
               leo.expires = new Date(Date.now() - 5000);
@@ -1303,10 +1358,30 @@ describe('Model', function (){
             .catch(done);
           });
 
+          it('Should return expired items if returnExpiredItems is true and expires is null (get)', function (done) {
+            Cats.ExpiringCatReturnTrue.create({
+              name: 'Leo11',
+              expires: new Date(new Date().getTime() + (1000 * 60 * 60 * 24 * 365))
+            })
+            .then(function (leo) {
+              leo.expires = null;
+              return leo.save();
+            })
+            .then(function () {
+              Cats.ExpiringCatReturnTrue.get("Leo11").then(function (leo) {
+                should.not.exist(leo.expires);
+                should.exist(leo);
+                done();
+              }).catch(done);
+            })
+            .catch(done);
+          });
+
 
           it('Should not return expired items if returnExpiredItems is false (batchGet)', function (done) {
             Cats.ExpiringCatNoReturn.create({
-              name: 'Leo2'
+              name: 'Leo2',
+              expires: new Date(new Date().getTime() + (1000 * 60 * 60 * 24 * 365))
             })
             .then(function (leo) {
               leo.expires = new Date(Date.now() - 5000);
@@ -1321,17 +1396,56 @@ describe('Model', function (){
             .catch(done);
           });
 
+          it('Should return expired items if returnExpiredItems is false and expires is null (batchGet)', function (done) {
+            Cats.ExpiringCatNoReturn.create({
+              name: 'Leo22',
+              expires: new Date(new Date().getTime() + (1000 * 60 * 60 * 24 * 365))
+            })
+            .then(function (leo) {
+              leo.expires = null;
+              return leo.save();
+            })
+            .then(function () {
+              Cats.ExpiringCatNoReturn.batchGet(["Leo22"]).then(function (leo) {
+                leo.length.should.eql(1);
+                should.not.exist(leo[0].expires);
+                done();
+              }).catch(done);
+            })
+            .catch(done);
+          });
+
           it('Should return expired items if returnExpiredItems is undefined (batchGet)', function (done) {
-            Cats.ExpiringCat.create({
-              name: 'Leo2'
+            Cats.ExpiringCatNull.create({
+              name: 'Leo2',
+              expires: new Date(new Date().getTime() + (1000 * 60 * 60 * 24 * 365))
             })
             .then(function (leo) {
               leo.expires = new Date(Date.now() - 5000);
               return leo.save();
             })
             .then(function () {
-              Cats.ExpiringCat.batchGet(["Leo2"]).then(function (leo) {
+              Cats.ExpiringCatNull.batchGet(["Leo2"]).then(function (leo) {
                 leo.length.should.eql(1);
+                done();
+              }).catch(done);
+            })
+            .catch(done);
+          });
+
+          it('Should return expired items if returnExpiredItems is undefined and expires is null (batchGet)', function (done) {
+            Cats.ExpiringCatNull.create({
+              name: 'Leo22',
+              expires: new Date(new Date().getTime() + (1000 * 60 * 60 * 24 * 365))
+            })
+            .then(function (leo) {
+              leo.expires = null;
+              return leo.save();
+            })
+            .then(function () {
+              Cats.ExpiringCatNull.batchGet(["Leo22"]).then(function (leo) {
+                leo.length.should.eql(1);
+                should.not.exist(leo[0].expires);
                 done();
               }).catch(done);
             })
@@ -1340,7 +1454,8 @@ describe('Model', function (){
 
           it('Should return expired items if returnExpiredItems is true (batchGet)', function (done) {
             Cats.ExpiringCatReturnTrue.create({
-              name: 'Leo2'
+              name: 'Leo2',
+              expires: new Date(new Date().getTime() + (1000 * 60 * 60 * 24 * 365))
             })
             .then(function (leo) {
               leo.expires = new Date(Date.now() - 5000);
@@ -1355,11 +1470,31 @@ describe('Model', function (){
             .catch(done);
           });
 
+          it('Should return expired items if returnExpiredItems is true and expires is null (batchGet)', function (done) {
+            Cats.ExpiringCatReturnTrue.create({
+              name: 'Leo22',
+              expires: new Date(new Date().getTime() + (1000 * 60 * 60 * 24 * 365))
+            })
+            .then(function (leo) {
+              leo.expires = null;
+              return leo.save();
+            })
+            .then(function () {
+              Cats.ExpiringCatReturnTrue.batchGet(["Leo22"]).then(function (leo) {
+                leo.length.should.eql(1);
+                should.not.exist(leo[0].expires);
+                done();
+              }).catch(done);
+            })
+            .catch(done);
+          });
+
 
 
           it('Should not return expired items if returnExpiredItems is false (scan)', function (done) {
             Cats.ExpiringCatNoReturn.create({
-              name: 'Leo3'
+              name: 'Leo3',
+              expires: new Date(new Date().getTime() + (1000 * 60 * 60 * 24 * 365))
             })
             .then(function (leo) {
               leo.expires = new Date(Date.now() - 5000);
@@ -1377,16 +1512,39 @@ describe('Model', function (){
             .catch(done);
           });
 
+          it('Should return expired items if returnExpiredItems is false and expires is null (scan)', function (done) {
+            Cats.ExpiringCatNoReturn.create({
+              name: 'Leo33',
+              expires: new Date(new Date().getTime() + (1000 * 60 * 60 * 24 * 365))
+            })
+            .then(function (leo) {
+              leo.expires = null;
+              return leo.save();
+            })
+            .then(function () {
+              Cats.ExpiringCatNoReturn.scan({name: 'Leo33'}, function (err, leo) {
+                if (err) {
+                  done(err);
+                }
+                leo.length.should.eql(1);
+                should.not.exist(leo[0].expires);
+                done();
+              });
+            })
+            .catch(done);
+          });
+
           it('Should return expired items if returnExpiredItems is undefined (scan)', function (done) {
-            Cats.ExpiringCat.create({
-              name: 'Leo3'
+            Cats.ExpiringCatNull.create({
+              name: 'Leo3',
+              expires: new Date(new Date().getTime() + (1000 * 60 * 60 * 24 * 365))
             })
             .then(function (leo) {
               leo.expires = new Date(Date.now() - 5000);
               return leo.save();
             })
             .then(function () {
-              Cats.ExpiringCat.scan({name: 'Leo3'}, function (err, leo) {
+              Cats.ExpiringCatNull.scan({name: 'Leo3'}, function (err, leo) {
                 if (err) {
                   done(err);
                 }
@@ -1397,9 +1555,32 @@ describe('Model', function (){
             .catch(done);
           });
 
+          it('Should return expired items if returnExpiredItems is undefined and expires is null (scan)', function (done) {
+            Cats.ExpiringCatNull.create({
+              name: 'Leo33',
+              expires: new Date(new Date().getTime() + (1000 * 60 * 60 * 24 * 365))
+            })
+            .then(function (leo) {
+              leo.expires = null;
+              return leo.save();
+            })
+            .then(function () {
+              Cats.ExpiringCatNull.scan({name: 'Leo33'}, function (err, leo) {
+                if (err) {
+                  done(err);
+                }
+                leo.length.should.eql(1);
+                should.not.exist(leo[0].expires);
+                done();
+              });
+            })
+            .catch(done);
+          });
+
           it('Should return expired items if returnExpiredItems is true (scan)', function (done) {
             Cats.ExpiringCatReturnTrue.create({
-              name: 'Leo3'
+              name: 'Leo3',
+              expires: new Date(new Date().getTime() + (1000 * 60 * 60 * 24 * 365))
             })
             .then(function (leo) {
               leo.expires = new Date(Date.now() - 5000);
@@ -1417,9 +1598,32 @@ describe('Model', function (){
             .catch(done);
           });
 
+          it('Should return expired items if returnExpiredItems is true and expires is null (scan)', function (done) {
+            Cats.ExpiringCatReturnTrue.create({
+              name: 'Leo33',
+              expires: new Date(new Date().getTime() + (1000 * 60 * 60 * 24 * 365))
+            })
+            .then(function (leo) {
+              leo.expires = null;
+              return leo.save();
+            })
+            .then(function () {
+              Cats.ExpiringCatReturnTrue.scan({name: 'Leo33'}, function (err, leo) {
+                if (err) {
+                  done(err);
+                }
+                leo.length.should.eql(1);
+                should.not.exist(leo[0].expires);
+                done();
+              });
+            })
+            .catch(done);
+          });
+
           it('Should not return expired items if returnExpiredItems is false (query)', function (done) {
             Cats.ExpiringCatNoReturn.create({
-              name: 'Leo4'
+              name: 'Leo4',
+              expires: new Date(new Date().getTime() + (1000 * 60 * 60 * 24 * 365))
             })
             .then(function (leo) {
               leo.expires = new Date(Date.now() - 5000);
@@ -1437,16 +1641,39 @@ describe('Model', function (){
             .catch(done);
           });
 
+          it('Should return expired items if returnExpiredItems is false and expires is null (query)', function (done) {
+            Cats.ExpiringCatNoReturn.create({
+              name: 'Leo44',
+              expires: new Date(new Date().getTime() + (1000 * 60 * 60 * 24 * 365))
+            })
+            .then(function (leo) {
+              leo.expires = null;
+              return leo.save();
+            })
+            .then(function () {
+              Cats.ExpiringCatNoReturn.query({name: 'Leo44'}, function (err, leo) {
+                if (err) {
+                  done(err);
+                }
+                leo.length.should.eql(1);
+                should.not.exist(leo[0].expires);
+                done();
+              });
+            })
+            .catch(done);
+          });
+
           it('Should return expired items if returnExpiredItems is undefined (query)', function (done) {
-            Cats.ExpiringCat.create({
-              name: 'Leo4'
+            Cats.ExpiringCatNull.create({
+              name: 'Leo4',
+              expires: new Date(new Date().getTime() + (1000 * 60 * 60 * 24 * 365))
             })
             .then(function (leo) {
               leo.expires = new Date(Date.now() - 5000);
               return leo.save();
             })
             .then(function () {
-              Cats.ExpiringCat.query({name: 'Leo4'}, function (err, leo) {
+              Cats.ExpiringCatNull.query({name: 'Leo4'}, function (err, leo) {
                 if (err) {
                   done(err);
                 }
@@ -1457,9 +1684,32 @@ describe('Model', function (){
             .catch(done);
           });
 
+          it('Should return expired items if returnExpiredItems is undefined and expires is null (query)', function (done) {
+            Cats.ExpiringCatNull.create({
+              name: 'Leo44',
+              expires: new Date(new Date().getTime() + (1000 * 60 * 60 * 24 * 365))
+            })
+            .then(function (leo) {
+              leo.expires = null;
+              return leo.save();
+            })
+            .then(function () {
+              Cats.ExpiringCatNull.query({name: 'Leo44'}, function (err, leo) {
+                if (err) {
+                  done(err);
+                }
+                leo.length.should.eql(1);
+                should.not.exist(leo[0].expires);
+                done();
+              });
+            })
+            .catch(done);
+          });
+
           it('Should return expired items if returnExpiredItems is true (query)', function (done) {
             Cats.ExpiringCatReturnTrue.create({
-              name: 'Leo4'
+              name: 'Leo4',
+              expires: new Date(new Date().getTime() + (1000 * 60 * 60 * 24 * 365))
             })
             .then(function (leo) {
               leo.expires = new Date(Date.now() - 5000);
@@ -1471,6 +1721,30 @@ describe('Model', function (){
                   done(err);
                 }
                 leo.length.should.eql(1);
+                done();
+              });
+            })
+            .catch(done);
+          });
+
+          it('Should return expired items if returnExpiredItems is true and expires is null (query)', function (done) {
+            Cats.ExpiringCatReturnTrue.create({
+              name: 'Leo44',
+              expires: new Date(new Date().getTime() + (1000 * 60 * 60 * 24 * 365))
+            })
+            .then(function (leo) {
+              leo.expires = null;
+              console.log(leo);
+              return leo.save();
+            })
+            .then(function () {
+              Cats.ExpiringCatReturnTrue.query({name: 'Leo44'}, function (err, leo) {
+                if (err) {
+                  done(err);
+                }
+                leo.length.should.eql(1);
+                console.log(leo);
+                should.not.exist(leo[0].expires);
                 done();
               });
             })
@@ -2511,7 +2785,7 @@ describe('Model', function (){
           var imageData = Buffer.from([0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x13, 0xd3, 0x61, 0x60, 0x60]);
 
           imageData.should.not.eql(Buffer.from(imageData.toString())); // The binary value should not be UTF-8 string for test.
-  
+
 
           var item = {
             id: 3333,

--- a/test/fixtures/Cats.js
+++ b/test/fixtures/Cats.js
@@ -204,6 +204,21 @@ module.exports = function(dynamoose){
     }
   );
 
+  var ExpiringCatNull = dynamoose.model('ExpiringCatNull',
+    {
+      name: String
+    },
+    {
+      expires: {
+        ttl: NINE_YEARS,
+        attribute: 'expires',
+        defaultExpires: function() {
+          return null;
+        }
+      }
+    }
+  );
+
   var ExpiringCatNoReturn = dynamoose.model('ExpiringCatNoReturn',
     {
       name: String
@@ -212,7 +227,10 @@ module.exports = function(dynamoose){
       expires: {
         ttl: NINE_YEARS,
         attribute: 'expires',
-        returnExpiredItems: false
+        returnExpiredItems: false,
+        defaultExpires: function() {
+          return null;
+        }
       }
     }
   );
@@ -225,7 +243,10 @@ module.exports = function(dynamoose){
       expires: {
         ttl: NINE_YEARS,
         attribute: 'expires',
-        returnExpiredItems: true
+        returnExpiredItems: true,
+        defaultExpires: function() {
+          return null;
+        }
       }
     }
   );
@@ -387,6 +408,7 @@ module.exports = function(dynamoose){
     CatWithOwner: CatWithOwner,
     Owner: Owner,
     ExpiringCat: ExpiringCat,
+    ExpiringCatNull: ExpiringCatNull,
     ExpiringCatNoReturn: ExpiringCatNoReturn,
     ExpiringCatReturnTrue: ExpiringCatReturnTrue,
     CatWithGeneratedID: CatWithGeneratedID,


### PR DESCRIPTION
### Summary:

This PR adds support for a `defaultExpires` property within the `expires` option.


### Code sample:
#### Schema
```
 var schema = new Schema({...}, {
  expires: {
    ttl: 7*24*60*60, // 1 week in seconds
    attribute: 'ttl', // ttl will be used as the attribute name
    returnExpiredItems: true // if expired items will be returned or not (default: true)
    returnExpiredItems: true, // if expired items will be returned or not (default: true)
    defaultExpires: function () { // optional, will default to `ttl` if not defined, this function is mainly used to allow the expires to be set to null or undefined, without resetting to the normal default
      // this code will be run if `ttl` is undefined or null
      return null;
    }
  }
});
```

#### General
```
var item = new Item();
item.title = "Hello World";
item.expires = new Date(new Date().getTime() + (1000 * 60 * 60 * 24 * 365));
item.save(function (err, itemB) {
  itemB.expires = null;
  itemB.save(function () {
    Item.get("Hello World", function (err, itemC) {
      console.log(itemC.expires); // null

      // Normally `itemC.expires` would have been reset back to the default `ttl` which in this case is (7*24*60*60)
      // But since we override the `defaultExpires` property that function will be run since `itemB.expires` was set to null
      // And that function returns null, so it will keep it's null value.
    });
  });
});
```


### Type (select 1):
- [ ] Bug fix
- [x] Feature implementation
- [ ] Documentation improvement
- [x] Testing improvement
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have run `npm test` from the root of the project directory to ensure all tests continue to pass
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have confirmed that all my code changes are indented properly using 2 spaces
- [x] I have filled out all fields above