### PR TITLE
Sorting index project array before comparing

### DIFF
--- a/lib/Table.js
+++ b/lib/Table.js
@@ -38,11 +38,11 @@ const compareIndexes = function compareIndexes(local, remote) {
         // let's see if the core data matches. if it doesn't,
         // we may need to delete the remote GSI and rebuild.
         let localIndex = (({ IndexName, KeySchema, Projection }) => ({ IndexName, KeySchema, Projection }))(localIndexes[i]);
-        if (localIndex && localIndex.Projection && localIndex.Projection.NonKeyAttributes) {
+        if (Array.isArray(localIndex && localIndex.Projection && localIndex.Projection.NonKeyAttributes)) {
           localIndex.Projection.NonKeyAttributes.sort();
         }
         let remoteIndex = (({ IndexName, KeySchema, Projection }) => ({ IndexName, KeySchema, Projection }))(remoteIndexes[j]);
-        if (remoteIndex && remoteIndex.Projection && remoteIndex.Projection.NonKeyAttributes) {
+        if (Array.isArray(remoteIndex && remoteIndex.Projection && remoteIndex.Projection.NonKeyAttributes)) {
           remoteIndex.Projection.NonKeyAttributes.sort();
         }
 

--- a/lib/Table.js
+++ b/lib/Table.js
@@ -38,7 +38,9 @@ const compareIndexes = function compareIndexes(local, remote) {
         // let's see if the core data matches. if it doesn't,
         // we may need to delete the remote GSI and rebuild.
         let localIndex = (({ IndexName, KeySchema, Projection }) => ({ IndexName, KeySchema, Projection }))(localIndexes[i]);
+        localIndex.Projection.NonKeyAttributes.sort();
         let remoteIndex = (({ IndexName, KeySchema, Projection }) => ({ IndexName, KeySchema, Projection }))(remoteIndexes[j]);
+        remoteIndex.Projection.NonKeyAttributes.sort();
 
         debug("indexes being compared");
         debug("local: ", localIndex);

--- a/lib/Table.js
+++ b/lib/Table.js
@@ -38,9 +38,13 @@ const compareIndexes = function compareIndexes(local, remote) {
         // let's see if the core data matches. if it doesn't,
         // we may need to delete the remote GSI and rebuild.
         let localIndex = (({ IndexName, KeySchema, Projection }) => ({ IndexName, KeySchema, Projection }))(localIndexes[i]);
-        localIndex.Projection.NonKeyAttributes.sort();
+        if (localIndex && localIndex.Projection && localIndex.Projection.NonKeyAttributes) {
+          localIndex.Projection.NonKeyAttributes.sort();
+        }
         let remoteIndex = (({ IndexName, KeySchema, Projection }) => ({ IndexName, KeySchema, Projection }))(remoteIndexes[j]);
-        remoteIndex.Projection.NonKeyAttributes.sort();
+        if (remoteIndex && remoteIndex.Projection && remoteIndex.Projection.NonKeyAttributes) {
+          remoteIndex.Projection.NonKeyAttributes.sort();
+        }
 
         debug("indexes being compared");
         debug("local: ", localIndex);


### PR DESCRIPTION
### Summary:

This PR fixes a bug that @dolsem reported in #453.  Basically we are sorting the index project array before comparing the local and remote indexes.


<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:
Closes #453


### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [ ] Yes
- [x] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have run `npm test` from the root of the project directory to ensure all tests continue to pass
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have confirmed that all my code changes are indented properly using 2 spaces
- [x] I have filled out all fields above