### PR TITLE
DynamoDB On-Demand Support

### DIFF
--- a/docs/_docs/schema.md
+++ b/docs/_docs/schema.md
@@ -183,9 +183,11 @@ Convert to uppercase when saving to DB.
 
 ### Options
 
-**throughput**: number &#124; {read: number, write: number}
+**throughput**: number | string &#124; {read: number, write: number}
 
 Sets the throughput of the DynamoDB table on creation. The value can either be a number or an object with the keys `read` and `write` (for example: `{read: 5, write: 2}`). If it is a number, both read and write are configured to that number. If it is omitted, the read and write values will be set to 1. Throughput will only be respected on table creation, and will not update the throughput of an existing table.
+
+If this property is set to `"ON_DEMAND"` the table will be created using PAY_PER_REQUEST BillingMode.
 
 ```js
 var schema = new Schema({...}, {

--- a/lib/Table.js
+++ b/lib/Table.js
@@ -391,17 +391,25 @@ const buildTableReq = Table.prototype.buildTableReq = function buildTableReq(nam
     });
   }
 
-  let provThroughput = {
-    ReadCapacityUnits: schema.throughput.read,
-    WriteCapacityUnits: schema.throughput.write
-  };
-
   let createTableReq = {
     AttributeDefinitions: attrDefs,
     TableName: name,
-    KeySchema: keySchema,
-    ProvisionedThroughput: provThroughput
+    KeySchema: keySchema
   };
+
+  if (schema.throughput === "ON_DEMAND") {
+    debug(`Using PAY_PER_REQUEST BillingMode for ${name} table creation`);
+    createTableReq.BillingMode = "PAY_PER_REQUEST";
+  } else {
+    debug(`Using PROVISIONED BillingMode for ${name} table creation`);
+    let provThroughput = {
+      ReadCapacityUnits: schema.throughput.read,
+      WriteCapacityUnits: schema.throughput.write
+    };
+    createTableReq.ProvisionedThroughput = provThroughput;
+    // The following line is commented out because DynamoDB Local currently throws an error when BillingMode is passed in (this should be uncommented when DynamoDB Local adds support for BillingMode, along with the two skipped tests in Model.js)
+    // createTableReq.BillingMode = "PROVISIONED";
+  }
 
   debug('Creating table local indexes', schema.indexes.local);
   let localSecIndexes, index;

--- a/lib/Table.js
+++ b/lib/Table.js
@@ -407,8 +407,7 @@ const buildTableReq = Table.prototype.buildTableReq = function buildTableReq(nam
       WriteCapacityUnits: schema.throughput.write
     };
     createTableReq.ProvisionedThroughput = provThroughput;
-    // The following line is commented out because DynamoDB Local currently throws an error when BillingMode is passed in (this should be uncommented when DynamoDB Local adds support for BillingMode, along with the two skipped tests in Model.js)
-    // createTableReq.BillingMode = "PROVISIONED";
+    createTableReq.BillingMode = "PROVISIONED";
   }
 
   debug('Creating table local indexes', schema.indexes.local);

--- a/test/Model.js
+++ b/test/Model.js
@@ -2757,8 +2757,7 @@ describe('Model', function (){
           Cats.Cat.getTableReq().ProvisionedThroughput.should.exist;
         });
 
-        // The following 2 tests are skipped because DynamoDB Local currently throws an error when BillingMode is passed in (these should be unskipped when DynamoDB Local adds support for BillingMode, along with the code to make them work in Table.js)
-    		it.skip('Should have BillingMode set to PROVISIONED when creating table, and no throughput defined', function() {
+    		it('Should have BillingMode set to PROVISIONED when creating table, and no throughput defined', function() {
           var BillModeSchema1 = new dynamoose.Schema({
             id: Number,
             name: String
@@ -2767,7 +2766,7 @@ describe('Model', function (){
 
     		  BillModeModel1.getTableReq().BillingMode.should.eql("PROVISIONED");
     		});
-        it.skip('Should have BillingMode set to PROVISIONED when creating table, and throughput defined', function() {
+        it('Should have BillingMode set to PROVISIONED when creating table, and throughput defined', function() {
           var BillModeSchema2 = new dynamoose.Schema({
             id: Number,
             name: String

--- a/test/Model.js
+++ b/test/Model.js
@@ -2757,15 +2757,15 @@ describe('Model', function (){
           Cats.Cat.getTableReq().ProvisionedThroughput.should.exist;
         });
 
-    		it('Should have BillingMode set to PROVISIONED when creating table, and no throughput defined', function() {
+        it('Should have BillingMode set to PROVISIONED when creating table, and no throughput defined', function() {
           var BillModeSchema1 = new dynamoose.Schema({
             id: Number,
             name: String
           });
           var BillModeModel1 = dynamoose.model('BillModeModel1', BillModeSchema1);
 
-    		  BillModeModel1.getTableReq().BillingMode.should.eql("PROVISIONED");
-    		});
+          BillModeModel1.getTableReq().BillingMode.should.eql("PROVISIONED");
+        });
         it('Should have BillingMode set to PROVISIONED when creating table, and throughput defined', function() {
           var BillModeSchema2 = new dynamoose.Schema({
             id: Number,

--- a/test/Model.js
+++ b/test/Model.js
@@ -2757,6 +2757,53 @@ describe('Model', function (){
           Cats.Cat.getTableReq().ProvisionedThroughput.should.exist;
         });
 
+        // The following 2 tests are skipped because DynamoDB Local currently throws an error when BillingMode is passed in (these should be unskipped when DynamoDB Local adds support for BillingMode, along with the code to make them work in Table.js)
+    		it.skip('Should have BillingMode set to PROVISIONED when creating table, and no throughput defined', function() {
+          var BillModeSchema1 = new dynamoose.Schema({
+            id: Number,
+            name: String
+          });
+          var BillModeModel1 = dynamoose.model('BillModeModel1', BillModeSchema1);
+
+    		  BillModeModel1.getTableReq().BillingMode.should.eql("PROVISIONED");
+    		});
+        it.skip('Should have BillingMode set to PROVISIONED when creating table, and throughput defined', function() {
+          var BillModeSchema2 = new dynamoose.Schema({
+            id: Number,
+            name: String
+          }, {throughput: {
+            write: 10,
+            read: 10
+          }});
+          var BillModeModel2 = dynamoose.model('BillModeModel2', BillModeSchema2);
+
+          BillModeModel2.getTableReq().BillingMode.should.eql("PROVISIONED");
+        });
+
+        it('Should have BillingMode set to PAY_PER_REQUEST when creating table, and throughput is ON_DEMAND', function() {
+          var BillModeSchema3 = new dynamoose.Schema({
+            id: Number,
+            name: String
+          }, {throughput: "ON_DEMAND"});
+          var BillModeModel3 = dynamoose.model('BillModeModel3', BillModeSchema3, {create: false});
+
+          BillModeModel3.getTableReq().BillingMode.should.eql("PAY_PER_REQUEST");
+        });
+
+        it('Should have correct throughput set when set', function() {
+          var BillModeSchema4 = new dynamoose.Schema({
+            id: Number,
+            name: String
+          }, {throughput: {
+            write: 10,
+            read: 10
+          }});
+          var BillModeModel4 = dynamoose.model('BillModeModel4', BillModeSchema4, {create: false});
+
+          BillModeModel4.getTableReq().ProvisionedThroughput.ReadCapacityUnits.should.eql(10);
+          BillModeModel4.getTableReq().ProvisionedThroughput.WriteCapacityUnits.should.eql(10);
+        });
+
         it('Should allow for originalItem function on models', function(done) {
           var item = {
             id: 2222,


### PR DESCRIPTION
### Summary:

This PR adds an option for `ON_DEMAND` for throughput for your schema to create the table using PAY_PER_REQUEST Billing Mode.

### Code sample:
#### Schema
```
var User = new dynamoose.Schema({
  id: Number,
  name: String
}, {
  throughput: "ON_DEMAND"
});
```


### GitHub linked issue:
Closes #470 


### Other information:

- Currently DynamoDB Local doesn't support the BillingMode property. Once support for that is added, we need to update this code. I have added comments for changes needed once that support is added.


### Type (select 1):
- [ ] Bug fix
- [x] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have run `npm test` from the root of the project directory to ensure all tests continue to pass
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have confirmed that all my code changes are indented properly using 2 spaces
- [x] I have filled out all fields above
