### PR TITLE
Return LastKey when using RAW Scan

### DIFF
--- a/lib/Scan.js
+++ b/lib/Scan.js
@@ -77,7 +77,7 @@ Scan.prototype.exec = function (next) {
           let counts = { count: data.Count, scannedCount: data.ScannedCount };
           return deferred.resolve(counts);
         }
-        return deferred.resolve(data.Items.map(function (item) {
+        let returnItems = data.Items.map(function (item) {
           let model;
 
           Object.keys(item).forEach(function (prop) {
@@ -90,7 +90,12 @@ Scan.prototype.exec = function (next) {
           model.$__.isNew = false;
           debug('scan parsed model', model);
           return model;
-        }).filter(item => !(schema.expires && schema.expires.returnExpiredItems === false && item[schema.expires.attribute] && item[schema.expires.attribute] < new Date())));
+        }).filter(item => !(schema.expires && schema.expires.returnExpiredItems === false && item[schema.expires.attribute] && item[schema.expires.attribute] < new Date()));
+
+        returnItems.lastKey = data.LastEvaluatedKey;
+        returnItems.count = data.Count;
+        returnItems.scannedCount = data.ScannedCount;
+        return deferred.resolve(returnItems);
       }
     });
 

--- a/test/Scan.js
+++ b/test/Scan.js
@@ -698,6 +698,24 @@ describe('Scan', function (){
       });
     });
 
+    it('Scan using raw AWS filter should work with lastKey', function (done) {
+      var Dog = dynamoose.model('Dog');
+      var filter = {
+        FilterExpression: 'ownerId > :ownerIdB',
+        ExpressionAttributeValues: {
+          ':ownerIdB': 1
+        },
+        Limit: 2
+      };
+
+      Dog.scan(filter, { useRawAwsFilter: true }).exec(function (err, dogs) {
+        should.not.exist(err);
+        should.exist(dogs.lastKey);
+
+        done();
+      });
+    });
+
     it('Scan using raw AWS filter and select count', function (done) {
       var Dog = dynamoose.model('Dog');
       var filter = {


### PR DESCRIPTION
### Summary:

This PR fixes a bug where the last key wouldn't be returned if doing a raw scan.


### GitHub linked issue:
Closes #474 


### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have run `npm test` from the root of the project directory to ensure all tests continue to pass
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have confirmed that all my code changes are indented properly using 2 spaces
- [x] I have filled out all fields above
