### PR TITLE
Allowing for passing object into query method

### DIFF
--- a/test/Query.js
+++ b/test/Query.js
@@ -724,4 +724,75 @@ describe('Query', function (){
       .exec();
     res2.length.should.eql(1);
   });
+
+  it('Should work for passing object into query', (done) => {
+    var Dog = dynamoose.model('Dog');
+
+    Dog.query({ownerId: {eq: 2}}).exec(function (err, dogs) {
+      should.not.exist(err);
+      dogs.length.should.eql(2);
+      done();
+    });
+  });
+
+  it('Should work for passing object into query with filter', (done) => {
+    var Dog2 = dynamoose.model('Dog2', new dynamoose.Schema({
+      id: Number,
+      name: String,
+      color: {
+        type: String,
+        index: {
+          global: true,
+          name: 'ColorIndex',
+          project: true
+        }
+      },
+      age: Number
+    }));
+    const dogs = [
+      {id: 1, name: "Bailey", color: "Brown", age: 5},
+      {id: 2, name: "Max", color: "Brown", age: 1},
+      {id: 3, name: "Toby", color: "Black", age: 1},
+      {id: 4, name: "Lucy", color: "Golden", age: 5}
+    ];
+    Promise.all(dogs.map(dog => Dog2.create(dog))).then(() => {
+      Dog2.query({color: {eq: "Brown"}, age: {gt: 2}}).exec()
+      .then(function (dogs) {
+        dogs.length.should.eql(1);
+        dogs[0].id.should.eql(1);
+        done();
+      })
+      .catch(done);
+    });
+  });
+
+  it('Should work for passing object into query with filters', (done) => {
+    var Dog3 = dynamoose.model('Dog3', new dynamoose.Schema({
+      id: Number,
+      name: String,
+      color: {
+        type: String,
+        index: {
+          global: true,
+          name: 'ColorIndex',
+          project: true
+        }
+      },
+      age: Number
+    }));
+    const dogs = [
+      {id: 1, name: "Bailey", color: "Brown", age: 5},
+      {id: 2, name: "Max", color: "Brown", age: 1},
+      {id: 3, name: "Toby", color: "Black", age: 1},
+      {id: 4, name: "Lucy", color: "Golden", age: 5}
+    ];
+    Promise.all(dogs.map(dog => Dog3.create(dog))).then(() => {
+      Dog3.query({color: {eq: "Brown"}, age: {gt: 2}, name: {eq: "Max"}}).exec()
+      .then(function (dogs) {
+        dogs.length.should.eql(0);
+        done();
+      })
+      .catch(done);
+    });
+  });
 });


### PR DESCRIPTION
### Summary:

This PR's goal is to add support for passing objects into the `Model.query` method.

Currently the following is supported:

```js
Dog.query({breed: {eq: 'Beagle'}}, function (err, dogs) {
  // Look at all the beagles
});
```

But the following is not:

```js
Dog.query({breed: {eq: 'Beagle'}, age: {gt: 5}}, function (err, dogs) {
  // Look at all the beagles (filtering out ages that are not greater than 5)
});
```

Basically the goal is to add support for doing filters in the query object itself.


### Type (select 1):
- [ ] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [x] Testing improvement
- [ ] Test added to report bug (GitHub issue #--- @---)
- [x] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [ ] Yes
- [x] No


### Are all the tests currently passing on this PR? (select 1):
- [ ] Yes
- [x] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [ ] I have run `npm test` from the root of the project directory to ensure all tests continue to pass
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have confirmed that all my code changes are indented properly using 2 spaces
- [x] I have filled out all fields above
