### PR TITLE
Throwing error when setting required attribute to empty string

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -747,6 +747,10 @@ Model.update = function(NewModel, key, update, options, next) {
 
     this.addRemove = function(name, item) {
       if(schema.hashKey.name !== name && (schema.rangeKey || {}).name !== name) {
+        let deleteAttr = schema.attributes[name];
+        if (deleteAttr.required) {
+          throw new errors.ValidationError('Required value missing: ' + this.name);
+        }
         this.REMOVE[name] = item;
       }
     };

--- a/test/Model.js
+++ b/test/Model.js
@@ -1011,6 +1011,16 @@ describe('Model', function (){
             });
           });
 
+          it("Should not update if setting required property to empty string", function(done) {
+            Cats.Cat12.create({id: 1234, name: "Sara"}).then(function() {
+              Cats.Cat12.update({id: 1234}, {name: ""}).then(function(cat) {
+                done("Should not allow setting a required propety to empty string");
+              }).catch(function() {
+                done();
+              })
+            });
+          });
+
           it("If key is null or undefined, will use defaults", function (done) {
             Cats.Cat3.update(null, {age: 3, name: 'Furrgie'}, function (err, data) {
               should.not.exist(err);

--- a/test/fixtures/Cats.js
+++ b/test/fixtures/Cats.js
@@ -392,6 +392,14 @@ module.exports = function(dynamoose){
   });
   var CatWithMethods = dynamoose.model('CatWithMethods', CatWithMethodsSchema);
 
+  var Cat12 = dynamoose.model('Cat12', {
+    id: Number,
+    name: {
+      type: String,
+      required: true
+    }
+  });
+
   return {
     Cat: Cat,
     Cat1: Cat1,
@@ -405,6 +413,7 @@ module.exports = function(dynamoose){
     Cat9: Cat9,
     Cat10: Cat10,
     Cat11: Cat11,
+    Cat12: Cat12,
     CatWithOwner: CatWithOwner,
     Owner: Owner,
     ExpiringCat: ExpiringCat,


### PR DESCRIPTION
### Summary:

This PR does not allow deleting an attribute that is required in the schema when preforming an update action.


### GitHub linked issue:
Closes #155 


### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [ ] No
- [x] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have run `npm test` from the root of the project directory to ensure all tests continue to pass
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have confirmed that all my code changes are indented properly using 2 spaces
- [x] I have filled out all fields above
