### PR TITLE
Fix support for PAY_PER_REQUEST BillingMode when Model includes Global Secondary Indexes

### DIFF
--- a/lib/Table.js
+++ b/lib/Table.js
@@ -467,13 +467,16 @@ const buildTableReq = Table.prototype.buildTableReq = function buildTableReq(nam
       KeySchema: [{
         AttributeName: globalIndexAttr.name,
         KeyType: 'HASH'
-      }],
-      ProvisionedThroughput: {
-        ReadCapacityUnits: index.throughput.read,
-        WriteCapacityUnits: index.throughput.write
-      }
+      }]
     };
 
+    if (createTableReq.BillingMode === "PROVISIONED") {
+      let provThroughput = {
+        ReadCapacityUnits: index.throughput.read,
+        WriteCapacityUnits: index.throughput.write
+      };
+      globalSecIndex.ProvisionedThroughput = provThroughput;
+    }
 
     if (index.rangeKey) {
       globalSecIndex.KeySchema.push({

--- a/test/Model.js
+++ b/test/Model.js
@@ -2875,6 +2875,30 @@ describe('Model', function (){
           BillModeModel4.getTableReq().ProvisionedThroughput.WriteCapacityUnits.should.eql(10);
         });
 
+        it('Should not have throughput on Global Secondary Index if Model throughput is ON_DEMAND', function() {
+          var BillModeSchema5 = new dynamoose.Schema({
+            id: Number,
+            name: { type: String, index: { global: true } }
+          }, {throughput: "ON_DEMAND"});
+          var BillModeModel5 = dynamoose.model('BillModeModel5', BillModeSchema5, {create: false});
+
+          should.not.exist(BillModeModel5.getTableReq().GlobalSecondaryIndexes[0].ProvisionedThroughput);
+        });
+
+        it('Should have correct throughput on Global Secondary Index if Model throughput is set', function() {
+          var BillModeSchema6 = new dynamoose.Schema({
+            id: Number,
+            name: { type: String, index: { global: true, throughput: { write: 5, read: 5 } } }
+          }, {throughput: {
+            write: 10,
+            read: 10
+          }});
+          var BillModeModel6 = dynamoose.model('BillModeModel6', BillModeSchema6, {create: false});
+
+          BillModeModel6.getTableReq().GlobalSecondaryIndexes[0].ProvisionedThroughput.ReadCapacityUnits.should.eql(5);
+          BillModeModel6.getTableReq().GlobalSecondaryIndexes[0].ProvisionedThroughput.WriteCapacityUnits.should.eql(5);
+        });
+
         it('Should allow for originalItem function on models', function(done) {
           var item = {
             id: 2222,


### PR DESCRIPTION
### Summary:

This PR fixes the option for `ON_DEMAND` throughput for creating tables using PAY_PER_REQUEST Billing Mode with Global Secondary Indexes.


<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:
#### Schema
```
var User = new dynamoose.Schema({
  id: Number,
  name: { type: String, index: { global: true } }
}, {
  throughput: "ON_DEMAND"
});
```

<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->
Closes #503 

### Type (select 1):
- [X] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [X] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [X] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [X] Yes
- [ ] No


### Other:
- [X] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [X] I have updated the Dynamoose documentation (if required) given the changes I made
- [X] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [X] I have run `npm test` from the root of the project directory to ensure all tests continue to pass
- [X] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [X] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [X] I have confirmed that all my code changes are indented properly using 2 spaces
- [X] I have filled out all fields above