### PR TITLE
Changing to not update timestamps when scaning or querying with filter

### DIFF
--- a/lib/Query.js
+++ b/lib/Query.js
@@ -170,7 +170,7 @@ Query.prototype.exec = async function (next) {
         for (i = 0; i < filter.values.length; i++) {
           val = filter.values[i];
           queryReq.QueryFilter[name].AttributeValueList.push(
-            isListContains ? await filterAttr.attributes[0].toDynamo(val, true) : await filterAttr.toDynamo(val, true)
+            isListContains ? await filterAttr.attributes[0].toDynamo(val, true, Model, {updateTimestamps: false}) : await filterAttr.toDynamo(val, true, Model, {updateTimestamps: false})
           );
         }
       }

--- a/lib/Scan.js
+++ b/lib/Scan.js
@@ -143,7 +143,7 @@ Scan.prototype.exec = async function (next) {
           for (let i = 0; i < filter.values.length; i++) {
             const val = filter.values[i];
             scanReq.ScanFilter[name].AttributeValueList.push(
-              isListContains ? await filterAttr.attributes[0].toDynamo(val, true) : await filterAttr.toDynamo(val, true)
+              isListContains ? await filterAttr.attributes[0].toDynamo(val, true, Model, {updateTimestamps: false}) : await filterAttr.toDynamo(val, true, Model, {updateTimestamps: false})
             );
           }
         }

--- a/test/Scan.js
+++ b/test/Scan.js
@@ -819,4 +819,49 @@ describe('Scan', function (){
     });
 
 
+    it('Should not set timestamps', async function () {
+      this.timeout(15000);
+
+      const Lion = dynamoose.model('Lion1', {
+        id: {
+          type: String,
+          hashKey: true,
+          trim: true,
+        },
+      }, {
+        timestamps: {
+          createdAt: 'created_at',
+          updatedAt: 'updated_at',
+        },
+      });
+
+      for (let i = 0; i < 10; i++) {
+        const record = {
+          id: `${i}`,
+        };
+
+        await new Lion(record).save();
+      }
+
+      // scan all records
+      const allRecords = await Lion.scan().all(0).exec();
+      allRecords.length.should.eql(10);
+
+      // filter by created_at
+      const tenMinAgo = new Date().getTime() - 10 * 60 * 1000;
+      const createdFilter = {
+        created_at: { gt: tenMinAgo },
+      }
+      const createdFilterRecords = await Lion.scan(createdFilter).all(0).exec();
+      createdFilterRecords.length.should.eql(10);
+
+      // filter by updated_at
+      const updatedFilter = {
+        updated_at: { gt: tenMinAgo },
+      }
+      const updatedFilterRecords = await Lion.scan(updatedFilter).all(0).exec();
+      updatedFilterRecords.length.should.eql(10);
+    });
+
+
   });


### PR DESCRIPTION
### Summary:




<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:
#### General
```
'use strict';

const dynamoose = require('dynamoose');
const uuidv4 = require('uuid/v4');

const sample = dynamoose.model(process.env.SAMPLE_TABLE, {
  id: {
    type: String,
    hashKey: true,
    trim: true,
  },
}, {
  timestamps: {
    createdAt: 'created_at',
    updatedAt: 'updated_at',
  },
});

dynamoose.AWS.config.update({
  accessKeyId: process.env.AKID,
  secretAccessKey: process.env.SECRET,
});

const main = async () => {
  // create records
  for (let i = 0; i < 10; i++) {
    const record = {
      id: uuidv4(),
    };

    await new sample(record).save();
  }

  // scan all records
  const allRecords = await sample.scan().all(0).exec();
  console.log('Count(all): ' + allRecords.length);

  // filter by created_at
  const tenMinAgo = new Date().getTime() - 10 * 60 * 1000;
  const createdFilter = {
    created_at: { gt: tenMinAgo },
  }
  const createdFilterRecords = await sample.scan(createdFilter).all(0).exec();
  console.log('Count(createdFilter): ' + createdFilterRecords.length);

  // filter by updated_at
  const updatedFilter = {
    updated_at: { gt: tenMinAgo },
  }
  const updatedFilterRecords = await sample.scan(updatedFilter).all(0).exec();
  console.log('Count(updatedFilter): ' + updatedFilterRecords.length);
};

main();
```


### GitHub linked issue:
Closes #508 


### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have run `npm test` from the root of the project directory to ensure all tests continue to pass
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have confirmed that all my code changes are indented properly using 2 spaces
- [x] I have filled out all fields above
