### PR TITLE
Fix error logging for data/schema mismatch

### DIFF
--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -547,7 +547,7 @@ Attribute.prototype.parseDynamo = async function(json) {
       try {
         return await transform(v, attr);
       } catch (e) {
-        e.message += `\nAttribute "${attr.name}" of type "${type}" has an invalid value of "${JSON.stringify(json[Object.keys(json)[0]])}"`
+        e.message += `\nAttribute "${attr.name}" of type "${type}" has an invalid value of ${JSON.stringify(json)}`
         throw new errors.ParseError(e.message);
       }
     }

--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -547,8 +547,8 @@ Attribute.prototype.parseDynamo = async function(json) {
       try {
         return await transform(v, attr);
       } catch (e) {
-        console.log(`Attribute "${attr.name}" of type "${type}" has an invalid value of "${JSON.stringify(json[Object.keys(json)[0]])}"`)
-        throw new errors.ParseError();
+        e.message += `\nAttribute "${attr.name}" of type "${type}" has an invalid value of "${JSON.stringify(json[Object.keys(json)[0]])}"`
+        throw e;
       }
     }
 

--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -543,27 +543,32 @@ Attribute.prototype.parseDynamo = async function(json) {
   }
 
   async function dedynamofy(type, isSet, json, transform, attr) {
-    try {
-      if(!json){
-        return;
+    const errorHandlingTransform = transform && async function (v) {
+      try {
+        return await transform(v, attr);
+      } catch (e) {
+        console.log(`Attribute "${attr.name}" of type "${type}" has an invalid value of "${JSON.stringify(json[Object.keys(json)[0]])}"`)
+        throw new errors.ParseError();
       }
-      if(isSet) {
-        const set = json[type + 'S'];
-        return (await Promise.all(set.map(async function (v) {
-          if(transform) {
-            return await transform(v);
-          }
-          return v;
-        })));
-      }
-      const val = json[type];
-      if(transform) {
-        return (await transform((val !== undefined) ? val : json, attr));
-      }
-      return val;
-    } catch (e) {
-      throw new errors.ParseError(`Attribute "${attr.name}" of type "${type}" has an invalid value of "${json[Object.keys(json)[0]]}"`, e);
     }
+
+    if(!json){
+      return;
+    }
+    if(isSet) {
+      const set = json[type + 'S'];
+      return (await Promise.all(set.map(async function (v) {
+        if(errorHandlingTransform) {
+          return await errorHandlingTransform(v);
+        }
+        return v;
+      })));
+    }
+    const val = json[type];
+    if(errorHandlingTransform) {
+      return (await errorHandlingTransform((val !== undefined) ? val : json));
+    }
+    return val;
   }
 
   async function mapify(v, attr){

--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -548,7 +548,7 @@ Attribute.prototype.parseDynamo = async function(json) {
         return await transform(v, attr);
       } catch (e) {
         e.message += `\nAttribute "${attr.name}" of type "${type}" has an invalid value of "${JSON.stringify(json[Object.keys(json)[0]])}"`
-        throw e;
+        throw new errors.ParseError(e.message);
       }
     }
 

--- a/test/Schema.js
+++ b/test/Schema.js
@@ -1041,6 +1041,28 @@ describe('Schema tests', function (){
     }
   });
 
+  it('Throws a useful error when parsing a record that does not match the schema', async function () {
+
+    const schema = new Schema({
+      topLevel: {
+        nestedField: Boolean,
+      }
+     });
+
+    var model = {};
+
+    try {
+      await schema.parseDynamo(model, {
+        topLevel: {
+          nestedField: 'This is a string',
+        }
+      });
+    } catch(err) {
+      err.should.be.instanceof(errors.ParseError);
+      err.message.should.match(/Attribute "nestedField" of type "BOOL" has an invalid value of "This is a string"/)
+    }
+  });
+
   it('Enum Should be set in schema attributes object', function (done) {
     var enumData = ['Golden retriever', 'Beagle'];
     var schema = new Schema({


### PR DESCRIPTION
### Summary:
The error handling for invalid data seems to have broken after making some callbacks asynchronous. I believe this fixes it.

I had to do something a bit strange: console.logging the error information prior to actually throwing a ParseError. When I tried just throwing a ParseError, for some reason I only got one log in the console. The info came from a top-level attribute, even though the actual offending attribute was nested within that top-level attribute. Separating the log into a separate message made it so both the top-level (parent) attribute and the actually incorrect (nested) attribute logged their info.

### GitHub linked issue:
#170, #331 

### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have run `npm test` from the root of the project directory to ensure all tests continue to pass
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have confirmed that all my code changes are indented properly using 2 spaces
- [x] I have filled out all fields above
