### PR TITLE
dynamoose.d.ts allow validate property on schema to return promise as well as raw boolean

### DIFF
--- a/dynamoose.d.ts
+++ b/dynamoose.d.ts
@@ -47,7 +47,7 @@ declare module "dynamoose" {
   }
   export interface SchemaAttributeDefinition<Constructor, Type> {
     type: Constructor;
-    validate?: (v: Type) => boolean;
+    validate?: (v: Type) => boolean | Promise<boolean>;
     hashKey?: boolean;
     rangeKey?: boolean;
     required?: boolean;


### PR DESCRIPTION
<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->


### Summary:
This PR is a type definition tweak.
The dynamoose validate expression allows you to return a promise that resolves to a boolean, ranther than just a boolean.

I added this to the type definition of the validate property on `SchemaAttributeDefinition`

### Type (select 1):
- [ ] Bug fix
- [ ] Feature implementation
- [x] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have run `npm test` from the root of the project directory to ensure all tests continue to pass
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have confirmed that all my code changes are indented properly using 2 spaces
- [x] I have filled out all fields above
