### PR TITLE
Make saveUnknown work recursively

### DIFF
--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -570,10 +570,17 @@ Attribute.prototype.parseDynamo = async function(json) {
     if(!v){ return; }
     let val = {};
 
-    for(const attrName in attr.attributes) {
-      const attrVal = await attr.attributes[attrName].parseDynamo(v[attrName]);
-      if(attrVal !== undefined && attrVal !== null){
-        val[attrName] = attrVal;
+    for(const [name, value] of Object.entries(v)) {
+      let subAttr = attr.attributes[name];
+      if (!subAttr && (attr.schema.options.saveUnknown || Array.isArray(attr.options.saveUnknown) && attr.options.saveUnknown.indexOf(name) >= 0)) {
+        subAttr = module.exports.createUnknownAttributeFromDynamo(attr.schema, name, value);
+        attr.schema.attributes[name] = subAttr;
+      }
+      if (subAttr) {
+        const attrVal = await subAttr.parseDynamo(value);
+        if(attrVal !== undefined && attrVal !== null){
+          val[name] = attrVal;
+        }
       }
     }
     return val;
@@ -705,9 +712,9 @@ function createAttrDefFromDynamo(dynamoAttribute) {
 }
 
 
-module.exports.createUnknownAttrbuteFromDynamo = function(schema, name, dynamoAttribute) {
+module.exports.createUnknownAttributeFromDynamo = function(schema, name, dynamoAttribute) {
 
-  debug('createUnknownAttrbuteFromDynamo: %j : "%s" : %j', schema, name, dynamoAttribute);
+  debug('createUnknownAttributeFromDynamo: %j : "%s" : %j', schema, name, dynamoAttribute);
   const attrDef = createAttrDefFromDynamo(dynamoAttribute);
   const attr = new Attribute(schema, name, attrDef);
   return attr;

--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -570,8 +570,10 @@ Attribute.prototype.parseDynamo = async function(json) {
     if(!v){ return; }
     let val = {};
 
+    // loop over all the properties of the input
     for(const [name, value] of Object.entries(v)) {
       let subAttr = attr.attributes[name];
+      // if saveUnknown is activated the input has an unknown attribute, let's create one on the fly.
       if (!subAttr && (attr.schema.options.saveUnknown || Array.isArray(attr.options.saveUnknown) && attr.options.saveUnknown.indexOf(name) >= 0)) {
         subAttr = createUnknownAttributeFromDynamo(attr.schema, name, value);
         attr.schema.attributes[name] = subAttr;

--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -573,7 +573,7 @@ Attribute.prototype.parseDynamo = async function(json) {
     for(const [name, value] of Object.entries(v)) {
       let subAttr = attr.attributes[name];
       if (!subAttr && (attr.schema.options.saveUnknown || Array.isArray(attr.options.saveUnknown) && attr.options.saveUnknown.indexOf(name) >= 0)) {
-        subAttr = module.exports.createUnknownAttributeFromDynamo(attr.schema, name, value);
+        subAttr = createUnknownAttributeFromDynamo(attr.schema, name, value);
         attr.schema.attributes[name] = subAttr;
       }
       if (subAttr) {
@@ -712,7 +712,7 @@ function createAttrDefFromDynamo(dynamoAttribute) {
 }
 
 
-module.exports.createUnknownAttributeFromDynamo = function(schema, name, dynamoAttribute) {
+const createUnknownAttributeFromDynamo = module.exports.createUnknownAttributeFromDynamo = function(schema, name, dynamoAttribute) {
 
   debug('createUnknownAttributeFromDynamo: %j : "%s" : %j', schema, name, dynamoAttribute);
   const attrDef = createAttrDefFromDynamo(dynamoAttribute);

--- a/lib/Schema.js
+++ b/lib/Schema.js
@@ -185,7 +185,7 @@ Schema.prototype.parseDynamo = async function(model, dynamoObj) {
     let attr = this.attributes[name];
 
     if((!attr && this.options.saveUnknown === true) || (this.options.saveUnknown instanceof Array && this.options.saveUnknown.indexOf(name) >= 0)) {
-      attr = Attribute.createUnknownAttrbuteFromDynamo(this, name, dynamoObj[name]);
+      attr = Attribute.createUnknownAttributeFromDynamo(this, name, dynamoObj[name]);
       this.attributes[name] = attr;
     }
 

--- a/test/Schema.js
+++ b/test/Schema.js
@@ -940,6 +940,7 @@ describe('Schema tests', function (){
 
     var schema = new Schema({
       id: Number,
+      anotherMap: Map,
     }, {
       saveUnknown: true
     });
@@ -952,6 +953,11 @@ describe('Schema tests', function (){
           aString: { S: 'Fluffy' },
           aNumber: { N: '5' },
         },
+      },
+      anotherMap: {
+        M: {
+          aNestedAttribute: { S: 'I am a nested attribute' }
+        }
       },
       listAttrib: {
         L: [
@@ -966,6 +972,9 @@ describe('Schema tests', function (){
       mapAttrib: {
         aString: 'Fluffy',
         aNumber: 5,
+      },
+      anotherMap: {
+        aNestedAttribute: 'I am a nested attribute'
       },
       listAttrib: [
         'v1',


### PR DESCRIPTION
### Summary:
When fetching from DynamoDB with `saveUnkown === true`, nested fields do not get returned. This PR aims to fix that.

### GitHub linked issue:
Closes #323 

### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have run `npm test` from the root of the project directory to ensure all tests continue to pass
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have confirmed that all my code changes are indented properly using 2 spaces
- [x] I have filled out all fields above
