### PR TITLE
Add error when not missing hash key for Model.get

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -551,8 +551,13 @@ Model.get = async function(NewModel, key, options, next) {
     return deferred.promise.nodeify(next);
   }
 
-  let schema = NewModel.$__.schema;
-  let hashKeyName = schema.hashKey.name;
+  const schema = NewModel.$__.schema;
+  const hashKeyName = schema.hashKey.name;
+
+  if (typeof key === 'object' && !validKeyValue(key[hashKeyName])) {
+    deferred.reject(new errors.ModelError('Hash key required: ' + schema.hashKey.name));
+    return deferred.promise.nodeify(next);
+  }
 
   if(!validKeyValue(key[hashKeyName])) {
     let keyVal = key;

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -555,7 +555,7 @@ Model.get = async function(NewModel, key, options, next) {
   const hashKeyName = schema.hashKey.name;
 
   if (typeof key === 'object' && !validKeyValue(key[hashKeyName])) {
-    deferred.reject(new errors.ModelError('Hash key required: ' + schema.hashKey.name));
+    deferred.reject(new errors.ModelError(`Hash key required: ${schema.hashKey.name}`));
     return deferred.promise.nodeify(next);
   }
 


### PR DESCRIPTION
### Summary:
Currently, if you pass an object to `Model.get` with only the range key of a table, you get an error saying `Range key required`, when in fact it is the the hash key that is missing. This PR adds an additional error for a missing hash key.

### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have run `npm test` from the root of the project directory to ensure all tests continue to pass
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have confirmed that all my code changes are indented properly using 2 spaces
- [x] I have filled out all fields above
