### PR TITLE
Fix parsing of sets when saveUnknown=true

### DIFF
--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -785,5 +785,8 @@ module.exports.lookupType = function (dynamoObj) {
   if(dynamoObj.NS !== null && dynamoObj.NS !== undefined) {
     return [Number];
   }
+  if(dynamoObj.SS !== null && dynamoObj.SS !== undefined) {
+    return [String];
+  }
 
 };

--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -205,16 +205,16 @@ Attribute.prototype.setTypeFromRawValue = function(value) {
     typeVal = value.type;
   }
 
-  if ( (util.isArray(typeVal) && typeVal.length === 1) || typeof typeVal === 'function') {
+  if ((util.isArray(typeVal) && typeof typeVal[0] !== 'function') || typeVal === 'list'){
+    type = 'List';
+  } else if ( (util.isArray(typeVal) && typeVal.length === 1) || typeof typeVal === 'function') {
     this.isSet = util.isArray(typeVal);
-    const regexFuncName = /^Function ([^(]+)\(/i;
-    const found = typeVal.toString().match(regexFuncName);
+    let regexFuncName = /^Function ([^(]+)\(/i;
+    let found = typeVal.toString().match(regexFuncName);
     type = found[1];
     if (type === 'Object') {
       type = 'Map';
     }
-  } else if (util.isArray(typeVal) || typeVal === 'list') {
-    type = 'List';
   } else if (typeof typeVal === 'object' || typeVal === 'map'){
     type = 'Map';
   } else {

--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -205,16 +205,16 @@ Attribute.prototype.setTypeFromRawValue = function(value) {
     typeVal = value.type;
   }
 
-  if (util.isArray(typeVal) || typeVal === 'list'){
-    type = 'List';
-  } else if ( (util.isArray(typeVal) && typeVal.length === 1) || typeof typeVal === 'function') {
+  if ( (util.isArray(typeVal) && typeVal.length === 1) || typeof typeVal === 'function') {
     this.isSet = util.isArray(typeVal);
-    let regexFuncName = /^Function ([^(]+)\(/i;
-    let found = typeVal.toString().match(regexFuncName);
+    const regexFuncName = /^Function ([^(]+)\(/i;
+    const found = typeVal.toString().match(regexFuncName);
     type = found[1];
     if (type === 'Object') {
       type = 'Map';
     }
+  } else if (util.isArray(typeVal) || typeVal === 'list') {
+    type = 'List';
   } else if (typeof typeVal === 'object' || typeVal === 'map'){
     type = 'Map';
   } else {

--- a/test/Schema.js
+++ b/test/Schema.js
@@ -953,6 +953,18 @@ describe('Schema tests', function (){
           aNumber: { N: '5' },
         },
       },
+      stringSet: {
+        SS: [
+          'String1',
+          'String2',
+        ],
+      },
+      numberSet: {
+        NS: [
+          1,
+          2
+        ],
+      },
       listAttrib: {
         L: [
           { S: 'v1' },
@@ -967,6 +979,74 @@ describe('Schema tests', function (){
         aString: 'Fluffy',
         aNumber: 5,
       },
+      stringSet: [
+        'String1',
+        'String2',
+      ],
+      numberSet: [
+        1,
+        2,
+      ],
+      listAttrib: [
+        'v1',
+        'v2',
+      ],
+    });
+  });
+
+  it('Parses known sets as sets, not arrays, when saveUnknown=true', async function () {
+
+    var schema = new Schema({
+      id: Number,
+      stringSet: [String],
+      numberSet: [Number],
+    }, {
+      saveUnknown: true
+    });
+
+    var model = {};
+    await schema.parseDynamo(model, {
+      id: { N: '2' },
+      mapAttrib: {
+        M: {
+          aString: { S: 'Fluffy' },
+          aNumber: { N: '5' },
+        },
+      },
+      stringSet: {
+        SS: [
+          'String1',
+          'String2',
+        ],
+      },
+      numberSet: {
+        NS: [
+          1,
+          2
+        ],
+      },
+      listAttrib: {
+        L: [
+          { S: 'v1' },
+          { S: 'v2' },
+        ],
+      },
+    });
+
+    model.should.eql({
+      id: 2,
+      mapAttrib: {
+        aString: 'Fluffy',
+        aNumber: 5,
+      },
+      stringSet: [
+        'String1',
+        'String2',
+      ],
+      numberSet: [
+        1,
+        2,
+      ],
       listAttrib: [
         'v1',
         'v2',


### PR DESCRIPTION
### Summary:
When `saveUnknown === true`, Dynamoose incorrectly parses sets as defined in a `Schema`. This PR resolves this issue.

### GitHub linked issue:
#516 

### Type (select 1):
- [x] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have run `npm test` from the root of the project directory to ensure all tests continue to pass
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have confirmed that all my code changes are indented properly using 2 spaces
- [x] I have filled out all fields above
