### PR TITLE
update typescript typings to allow `ON_DEMAND` throughput in SchemaOptions

### DIFF
--- a/dynamoose.d.ts
+++ b/dynamoose.d.ts
@@ -64,7 +64,7 @@ declare module "dynamoose" {
     default?: (() => Type) | Type
   }
   export interface SchemaOptions {
-    throughput?: boolean | { read: number, write: number };
+    throughput?: boolean | { read: number, write: number } | "ON_DEMAND";
     useNativeBooleans?: boolean;
     useDocumentTypes?: boolean;
     timestamps?: boolean | { createdAt: string, updatedAt: string };


### PR DESCRIPTION
### Summary:

Update the typescript typings to allow the `ON_DEMAND` setting to be passed to the `throughput` parameter in `SchemaOptions`

### Type (select 1):
- [x ] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement
<!-- If you select the option below, please replace `---` below with the issue number of the GitHub issue raised, and the user who asked you to submit a broken test -->
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [ ] I have updated the Dynamoose documentation (if required) given the changes I made
- [ ] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have run `npm test` from the root of the project directory to ensure all tests continue to pass
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have confirmed that all my code changes are indented properly using 2 spaces
- [x] I have filled out all fields above
