### PR TITLE
errorUnknown

### DIFF
--- a/docs/_docs/schema.md
+++ b/docs/_docs/schema.md
@@ -412,6 +412,16 @@ var schema = new Schema({...}, {
 });
 ```
 
+**errorUnknown**: boolean
+
+Specifies that any attributes not defined in the _schema_ will throw an error if encountered while parsing records from DynamoDB. This defaults to false.
+
+```js
+var schema = new Schema({...}, {
+  errorUnknown: true
+});
+```
+
 **attributeToDynamo**: function
 
 A function that accepts `name, json, model, defaultFormatter, options`.

--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -579,7 +579,9 @@ Attribute.prototype.parseDynamo = async function(json) {
     for(const [name, value] of Object.entries(v)) {
       let subAttr = attr.attributes[name];
       // if saveUnknown is activated the input has an unknown attribute, let's create one on the fly.
-      if (!subAttr && attr.schema.options.errorUnknown) throw new errors.ParseError(`unknown attribute ${name}: ${JSON.stringify(value)}`);
+      if (!subAttr && attr.schema.options.errorUnknown) {
+        throw new errors.ParseError(`Unknown attribute ${name}: ${JSON.stringify(value)}`);
+      }
       if (!subAttr && (attr.schema.options.saveUnknown || Array.isArray(attr.options.saveUnknown) && attr.options.saveUnknown.indexOf(name) >= 0)) {
         subAttr = createUnknownAttributeFromDynamo(attr.schema, name, value);
         attr.schema.attributes[name] = subAttr;

--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -579,6 +579,7 @@ Attribute.prototype.parseDynamo = async function(json) {
     for(const [name, value] of Object.entries(v)) {
       let subAttr = attr.attributes[name];
       // if saveUnknown is activated the input has an unknown attribute, let's create one on the fly.
+      if (!subAttr && attr.schema.options.errorUnknown) throw new errors.ParseError(`unknown attribute ${name}: ${JSON.stringify(value)}`);
       if (!subAttr && (attr.schema.options.saveUnknown || Array.isArray(attr.options.saveUnknown) && attr.options.saveUnknown.indexOf(name) >= 0)) {
         subAttr = createUnknownAttributeFromDynamo(attr.schema, name, value);
         attr.schema.attributes[name] = subAttr;

--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -575,16 +575,17 @@ Attribute.prototype.parseDynamo = async function(json) {
     if(!v){ return; }
     let val = {};
 
+    const { attributes, schema } = attr;
     // loop over all the properties of the input
     for(const [name, value] of Object.entries(v)) {
-      let subAttr = attr.attributes[name];
+      let subAttr = attributes[name];
       // if saveUnknown is activated the input has an unknown attribute, let's create one on the fly.
-      if (!subAttr && attr.schema.options.errorUnknown) {
-        throw new errors.ParseError(`Unknown attribute ${name}: ${JSON.stringify(value)}`);
+      if (!subAttr && schema.options.errorUnknown) {
+        throw new errors.ParseError(`Unknown nested attribute ${name} with value: ${JSON.stringify(value)}`);
       }
-      if (!subAttr && (attr.schema.options.saveUnknown || Array.isArray(attr.options.saveUnknown) && attr.options.saveUnknown.indexOf(name) >= 0)) {
-        subAttr = createUnknownAttributeFromDynamo(attr.schema, name, value);
-        attr.schema.attributes[name] = subAttr;
+      if (!subAttr && (schema.options.saveUnknown || Array.isArray(schema.options.saveUnknown) && schema.options.saveUnknown.indexOf(name) >= 0)) {
+        subAttr = createUnknownAttributeFromDynamo(schema, name, value);
+        attr.attributes[name] = subAttr;
       }
       if (subAttr) {
         const attrVal = await subAttr.parseDynamo(value);

--- a/lib/Schema.js
+++ b/lib/Schema.js
@@ -181,9 +181,11 @@ Schema.prototype.toDynamo = async function(model, options) {
 
 Schema.prototype.parseDynamo = async function(model, dynamoObj) {
 
+  debug('MADE IT')
   for(const name in dynamoObj) {
     let attr = this.attributes[name];
 
+    if (!attr && this.options.errorUnknown) throw new errors.ParseError(`unknown top-level attribute ${name} on model ${model.$__.name}: ${JSON.stringify(dynamoObj[name])}`)
     if((!attr && this.options.saveUnknown === true) || (Array.isArray(this.options.saveUnknown) && this.options.saveUnknown.indexOf(name) >= 0)) {
       attr = Attribute.createUnknownAttributeFromDynamo(this, name, dynamoObj[name]);
       this.attributes[name] = attr;

--- a/lib/Schema.js
+++ b/lib/Schema.js
@@ -185,7 +185,9 @@ Schema.prototype.parseDynamo = async function(model, dynamoObj) {
   for(const name in dynamoObj) {
     let attr = this.attributes[name];
 
-    if (!attr && this.options.errorUnknown) throw new errors.ParseError(`unknown top-level attribute ${name} on model ${model.$__.name}: ${JSON.stringify(dynamoObj[name])}`)
+    if (!attr && this.options.errorUnknown) {
+      throw new errors.ParseError(`Unknown top-level attribute ${name} on model ${model.$__.name}: ${JSON.stringify(dynamoObj[name])}`)
+    }
     if((!attr && this.options.saveUnknown === true) || (Array.isArray(this.options.saveUnknown) && this.options.saveUnknown.indexOf(name) >= 0)) {
       attr = Attribute.createUnknownAttributeFromDynamo(this, name, dynamoObj[name]);
       this.attributes[name] = attr;

--- a/lib/Schema.js
+++ b/lib/Schema.js
@@ -181,12 +181,17 @@ Schema.prototype.toDynamo = async function(model, options) {
 
 Schema.prototype.parseDynamo = async function(model, dynamoObj) {
 
-  debug('MADE IT')
   for(const name in dynamoObj) {
     let attr = this.attributes[name];
 
     if (!attr && this.options.errorUnknown) {
-      throw new errors.ParseError(`Unknown top-level attribute ${name} on model ${model.$__.name}: ${JSON.stringify(dynamoObj[name])}`)
+      const hashKey = this.hashKey && this.hashKey.name && dynamoObj[this.hashKey.name] && JSON.stringify(dynamoObj[this.hashKey.name]);
+      const rangeKey = this.rangeKey && this.rangeKey.name && JSON.stringify(dynamoObj[this.rangeKey.name]);
+      let errorMessage = `Unknown top-level attribute ${name} on model ${model.$__.name} with `;
+      if (hashKey) errorMessage += `hash-key ${hashKey} and `;
+      if (rangeKey) errorMessage += `range-key ${rangeKey} and `;
+      errorMessage += `value: ${JSON.stringify(dynamoObj[name])}`;
+      throw new errors.ParseError(errorMessage)
     }
     if((!attr && this.options.saveUnknown === true) || (Array.isArray(this.options.saveUnknown) && this.options.saveUnknown.indexOf(name) >= 0)) {
       attr = Attribute.createUnknownAttributeFromDynamo(this, name, dynamoObj[name]);

--- a/test/Schema.js
+++ b/test/Schema.js
@@ -1213,6 +1213,46 @@ describe('Schema tests', function (){
     });
   });
 
+
+  it('Errors when encountering an unknown attribute if errorUnknown is set to true', async function () {
+    const schema = new Schema({
+      knownAttribute: String,
+     }, {
+       errorUnknown: true,
+    });
+
+    let err;
+    const model = {['$__']: {
+      name: 'OnlyKnownAttributesModel'
+    }};
+    try {
+      await schema.parseDynamo(model, {
+        knownAttribute: { S: 'I am known to the schema. Everything is groovy.' },
+        unknownAttribute: { S: 'I am but a stranger to the schema. I should cause an error.' }
+      });
+    } catch (e) {
+      err = e;
+    }
+
+    err.should.be.instanceof(errors.ParseError);
+    err = undefined;
+
+    try {
+      await schema.parseDynamo(model, {
+        knownAttribute: { S: 'I am known to the schema. Everything is groovy.' },
+        myMap: {
+          M: {
+            nestedUnknownAttribute: { S: 'I too am a stranger. Will the schema be able to find me down here?' }
+          }
+        }
+      });
+    } catch (e) {
+      err = e;
+    }
+
+    err.should.be.instanceof(errors.ParseError);
+  });
+
   it('Should throw error when type is map but no map is provided', function (done) {
     let err;
     try {


### PR DESCRIPTION
### Summary:
`errorUnknown`, when set to true, will throw an error if `parseDynamo`
encounters a record with a field at any level that is not specified in
the Schema.

#### Schema
```javascript
const schema = new Schema({
  knownAttribute: String,
}, {
  errorUnknown: true,
});
```

#### General
If this record were encountered with the above schema, an error would be
thrown.
```javascript
const record = {
  knownAttribute: { S: 'I am known to the schema. Everything is groovy.' },
  unknownAttribute: { S: 'I am but a stranger to the schema. I will cause an error.' }
}
```

### Type (select 1):
- [ ] Bug fix
- [x] Feature implementation
- [ ] Documentation improvement
- [ ] Testing improvement

### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure

### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No

### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No

### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have run `npm test` from the root of the project directory to ensure all tests continue to pass
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have confirmed that all my code changes are indented properly using 2 spaces
- [x] I have filled out all fields above