### PR TITLE
defaultReturnValues

### DIFF
--- a/docs/_docs/config.md
+++ b/docs/_docs/config.md
@@ -33,6 +33,7 @@ Default `options`:
     type: undefined // sets the stream type (NEW_IMAGE | OLD_IMAGE | NEW_AND_OLD_IMAGES | KEYS_ONLY) (https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_StreamSpecification.html#DDB-Type-StreamSpecification-StreamViewType)
   },
   serverSideEncryption: false // Set SSESpecification.Enabled (server-side encryption) to true or false (default: true)
+  defaultReturnValues: 'ALL_NEW' // sets ReturnValues for the UpdateItem operation (NONE | ALL_OLD | UPDATED_OLD | ALL_NEW | UPDATED_NEW) (https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateItem.html)
 }
 ```
 

--- a/docs/_docs/model.md
+++ b/docs/_docs/model.md
@@ -441,10 +441,10 @@ match schema attribute names.
 From [the AWS documentation](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateItem.html)
 Use ReturnValues if you want to get the item attributes as they appear before or after they are updated. For UpdateItem, the valid values are:
 
-- NONE - If ReturnValues is not specified, or if its value is NONE, then nothing is returned. (This setting is the default for ReturnValues.)
+- NONE - If ReturnValues is not specified, or if its value is NONE, then nothing is returned. (This setting is DynamoDB's default.)
 - ALL_OLD - Returns all of the attributes of the item, as they appeared before the UpdateItem operation.
 - UPDATED_OLD - Returns only the updated attributes, as they appeared before the UpdateItem operation.
-- ALL_NEW - Returns all of the attributes of the item, as they appear after the UpdateItem operation.
+- ALL_NEW - Returns all of the attributes of the item, as they appear after the UpdateItem operation. (This setting is Dynamoose's default.)
 - UPDATED_NEW - Returns only the updated attributes, as they appear after the UpdateItem operation.
 
 

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -738,9 +738,9 @@ Model.update = async function(NewModel, key, update, options, next) {
     options.updateTimestamps = true;
   }
 
-  // default return values to 'NEW_ALL'
+  // default return values to 'ALL_NEW' unless `defaultReturnValues` is set;
   if (typeof options.returnValues === 'undefined') {
-    options.returnValues = 'ALL_NEW';
+    options.returnValues = NewModel.$__.options.defaultReturnValues || 'ALL_NEW';
   }
 
   // if the key part was emtpy, try the key defaults before giving up...

--- a/test/Model.js
+++ b/test/Model.js
@@ -2314,6 +2314,14 @@ describe('Model', function (){
             });
           });
 
+          it("Update respects global defaultReturnValues option", function () {
+            return Cats.ReturnValuesNoneCat.create({id: '678', name: 'Oliver'}, {overwrite: true}).then(function(old){
+              return Cats.ReturnValuesNoneCat.update({id: old.id}, {name: 'Tom'}).then(function(data){
+                should.not.exist(data);
+              });
+            });
+          });
+
           it("Update returns updated new values using 'UPDATED_NEW'", function () {
             return Cats.Cat.create({id: '678', name: 'Oliver'}, {overwrite: true}).then(function(old){
               return Cats.Cat.update({id: old.id}, {name: 'Tom'}, {returnValues: 'UPDATED_NEW'}).then(function(data){

--- a/test/fixtures/Cats.js
+++ b/test/fixtures/Cats.js
@@ -401,6 +401,13 @@ module.exports = function(dynamoose){
   });
   var CatWithMethods = dynamoose.model('CatWithMethods', CatWithMethodsSchema);
 
+  const ReturnValuesNoneCat = dynamoose.model('ReturnValuesNoneCat', {
+    id: Number,
+    name: String,
+  },{
+    defaultReturnValues: 'NONE',
+  })
+
   return {
     Cat: Cat,
     Cat1: Cat1,
@@ -423,6 +430,7 @@ module.exports = function(dynamoose){
     ExpiringCatReturnTrue: ExpiringCatReturnTrue,
     CatWithGeneratedID: CatWithGeneratedID,
     CatWithMethods: CatWithMethods,
-    CatModel: CatModel
+    CatModel: CatModel,
+    ReturnValuesNoneCat,
   };
 };


### PR DESCRIPTION
### Summary:
Add `defaultReturnValues`

#### Model
```javascript
  const ReturnValuesNoneCat = dynamoose.model('ReturnValuesNoneCat', {
    id: Number,
    name: String,
  },{
    defaultReturnValues: 'NONE',
  })
```

#### General
When invoking `Model.update`, `ReturnValuesNoneCat` will return
`undefined` as opposed to the full record as is the default behavior
because when defining the model, the option `defaultReturnValues` was
set to `true`.

```javascript
  await ReturnValuesNoneCat.update({id: 1}, {name: 'Tom'});
  // undefined
```

### Type (select 1):
- [ ] Bug fix
- [x] Feature implementation
- [x] Documentation improvement
- [ ] Testing improvement

### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure

### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No

### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No

### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have run `npm test` from the root of the project directory to ensure all tests continue to pass
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have confirmed that all my code changes are indented properly using 2 spaces
- [x] I have filled out all fields above