### PR TITLE
Refactor transactions tests to use DynamoDB Local tests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,95 +10,9 @@ const Q = require('q');
 const errors = require('./errors');
 
 function createLocalDb(endpointURL) {
-  const client = new AWS.DynamoDB({
+  return new AWS.DynamoDB({
     endpoint: new AWS.Endpoint(endpointURL)
   });
-
-  if (typeof global.it !== 'function' && typeof global.after !== 'function') {
-    // We're not running in a test env - just return the client without modifications.
-    // This ensures that we keep BC with users that might call this method in produciton applications.
-    // @TODO: Remove once DynamoDB local instance supports transactions.
-    return client;
-  }
-
-  // @TODO: Remove once DynamoDB local instance supports transactions.
-  // @HACK
-  client.transactGetItems = (request, callback) => {
-    const batchRequest = {
-      RequestItems: {}
-    };
-    request.TransactItems.forEach((item) => {
-      const operation = Object.keys(item)[0];
-      const transactItem = item[operation];
-      if (!batchRequest.RequestItems[transactItem.TableName]) {
-        batchRequest.RequestItems[transactItem.TableName] = {
-          Keys: []
-        };
-      }
-
-      batchRequest.RequestItems[transactItem.TableName].Keys.push(transactItem.Key);
-    });
-    return client.batchGetItem(batchRequest, (err, data) => {
-      if (err) {
-        return callback(err);
-      }
-      // Re-map responses to expected format.
-      data.Responses = Object.values(data.Responses).reduce(
-        (list, resp) => ([...list, ...resp.map((item) => ({Item: item}))]),
-        []
-      );
-      callback(err, data);
-    });
-
-  };
-
-  // @TODO: Remove once DynamoDB local instance supports transactions.
-  // @HACK
-  client.transactWriteItems = (request, callback) => {
-    const batchRequest = {
-      RequestItems: {}
-    };
-    request.TransactItems.forEach((item) => {
-      let operation = Object.keys(item)[0];
-      const transactItem = item[operation];
-
-      if (operation === 'ConditionCheck') {
-        // Mock does not support ConditionCheck operation, so just fail silently.
-        // Bail out early to not create a request with empty table name.
-        return;
-      }
-
-      if (!batchRequest.RequestItems[transactItem.TableName]) {
-        batchRequest.RequestItems[transactItem.TableName] = [];
-      }
-
-      // Pick only properties that we're interested in.
-      const {Key, Item} = transactItem;
-
-      const itemValue = {};
-
-      if (operation === 'Update') {
-        // Map Key to update to to item, since Put only supports Item.
-        itemValue.Item = Key;
-      } else if (Key) {
-        itemValue.Key = Key;
-      } else if (Item) {
-        itemValue.Item = Item;
-      }
-
-      if (operation === 'Update') {
-        // Map Update operation to Put, as this mock does not support Update operations.
-        operation = 'Put';
-      }
-
-      batchRequest.RequestItems[transactItem.TableName].push({
-        [`${operation}Request`]: itemValue
-      });
-    });
-    return client.batchWriteItem(batchRequest, callback);
-  };
-
-  return client;
 }
 
 function Dynamoose () {

--- a/test/Model.js
+++ b/test/Model.js
@@ -3512,57 +3512,64 @@ describe('Model', function (){
       });
     });
 
-    it('Should respond with no data', function(done) {
-      dynamoose.transaction([
-        Cats.Cat.transaction.create({id: 10000}),
-        Cats.Cat3.transaction.update({id: 1, name: 'Sara'}),
-        // @TODO: use 10000 as in the first transaction. Currenly local mock requires us to use unique IDs.
-        Cats.Cat.transaction.delete({id: 10001})
-      ]).then(function(result) {
-        should.not.exist(result);
+    it('Should respond with no data', async function() {
+      let result;
 
-        done();
-      }).catch(done);
+      try {
+        result = await dynamoose.transaction([
+          Cats.Cat.transaction.create({id: 10000}),
+          Cats.Cat3.transaction.update({id: 1, name: 'Sara'}),
+          Cats.Cat.transaction.delete({id: 10000})
+        ]);
+      } catch (e) {
+      }
+
+      should.not.exist(result);
     });
 
-    it('Should throw if RAW item object passed in, and table doesn\'t exist in Dynamoose', function(done) {
-      dynamoose.transaction([
-        Cats.Cat.transaction.create({id: 30000}),
-        Cats.Cat3.transaction.update({id: 1, name: 'Sara'}),
-        // @TODO: use 10000 as in the first transaction. Currenly local mock requires us to use unique IDs.
-        Cats.Cat.transaction.delete({id: 30001}),
-        {
-          Delete: {
-            Key: {
-              id: {
-                S: 'helloworld'
-              }
-            },
-            TableName: 'MyOtherTable'
+    it('Should throw if RAW item object passed in, and table doesn\'t exist in Dynamoose', async function() {
+      let error;
+
+      try {
+        await dynamoose.transaction([
+          Cats.Cat.transaction.create({id: 30000}),
+          Cats.Cat3.transaction.update({id: 1, name: 'Sara'}),
+          Cats.Cat.transaction.delete({id: 30000}),
+          {
+            Delete: {
+              Key: {
+                id: {
+                  S: 'helloworld'
+                }
+              },
+              TableName: 'MyOtherTable'
+            }
           }
-        }
-      ]).then(function () {
-      }).catch(function (error) {
-        should.exist(error);
-        error.message.should.eql('MyOtherTable is not a registered model. You can only use registered Dynamoose models when using a RAW transaction object.');
-        done();
-      });
+        ]);
+      } catch (e) {
+        error = e;
+      }
+
+      should.exist(error);
+      error.message.should.eql('MyOtherTable is not a registered model. You can only use registered Dynamoose models when using a RAW transaction object.');
     });
 
-    it('Should work with conditionCheck', function(done) {
-      dynamoose.transaction([
-        Cats.Cat.transaction.create({id: 20000}),
-        Cats.Cat3.transaction.update({id: 1, name: 'Sara'}),
-        Cats.Cat5.transaction.conditionCheck(5, {
-          condition: 'attribute_not_exists(owner)'
-        }),
-        // @TODO: use 20000 as in the first transaction. Currenly local mock requires us to use unique IDs.
-        Cats.Cat.transaction.delete({id: 20001})
-      ]).then(function(result) {
-        should.not.exist(result);
+    it('Should work with conditionCheck', async function() {
+      let result;
 
-        done();
-      }).catch(done);
+      try {
+        result = await dynamoose.transaction([
+          Cats.Cat.transaction.create({id: 20000}),
+          Cats.Cat3.transaction.update({id: 1, name: 'Sara'}),
+          Cats.Cat5.transaction.conditionCheck(5, {
+            condition: 'attribute_not_exists(owner)'
+          }),
+          Cats.Cat.transaction.delete({id: 20000})
+        ]);
+      } catch (e) {
+      }
+
+      should.not.exist(result);
     });
   });
 });

--- a/test/Model.js
+++ b/test/Model.js
@@ -3522,6 +3522,7 @@ describe('Model', function (){
           Cats.Cat.transaction.delete({id: 10000})
         ]);
       } catch (e) {
+        console.error(e);
       }
 
       should.not.exist(result);
@@ -3567,6 +3568,7 @@ describe('Model', function (){
           Cats.Cat.transaction.delete({id: 20000})
         ]);
       } catch (e) {
+        console.error(e);
       }
 
       should.not.exist(result);


### PR DESCRIPTION
### Summary:

This PR updates the hacks used to get around the fact that DynamoDB Local didn't support transactions.


### GitHub linked issue:
Closes #479 


### Type (select 1):
- [ ] Bug fix
- [ ] Feature implementation
- [ ] Documentation improvement
- [x] Testing improvement
- [ ] Test added to report bug (GitHub issue #--- @---)
- [ ] Something not listed here


### Is this a breaking change? (select 1):
- [ ] 🚨 YES 🚨
- [x] No
- [ ] I'm not sure


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Are all the tests currently passing on this PR? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I have ensured the following commands are successful from the root of the project directory
  - [x] `npm test`
  - [x] `eslint .`
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
