### PR TITLE
Fixing saveUnknown toDynamo for maps

### DIFF
--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -468,18 +468,22 @@ Attribute.prototype.toDynamo = async function(val, noSet, model, options) {
       return v;
     }.bind(this));
   } else if (type.name === 'map') {
-
     let dynamoMapObj = {};
-    for(const name in this.attributes) {
-      const attr = this.attributes[name];
-      await attr.setDefault(model);
-      const dynamoAttr = await attr.toDynamo(val[name], undefined, model);
-      if(dynamoAttr) {
-        dynamoMapObj[attr.name] = dynamoAttr;
+    for(const [name, value] of Object.entries(val)) {
+      let subAttr = this.attributes[name];
+      // if saveUnknown is activated the input has an unknown attribute, let's create one on the fly.
+      if (!subAttr && (this.schema.options.saveUnknown || Array.isArray(this.options.saveUnknown) && this.options.saveUnknown.indexOf(name) >= 0)) {
+        subAttr = module.exports.create(this.schema, name, value);
+        this.attributes[name] = subAttr;
+      }
+      if (subAttr) {
+        const attrVal = await subAttr.toDynamo(value);
+        if (attrVal !== undefined && attrVal !== null) {
+          dynamoMapObj[name] = attrVal;
+        }
       }
     }
     dynamoObj.M = dynamoMapObj;
-
   } else if (type.name === 'list') {
 
     if (!Array.isArray(val)) {

--- a/test/Schema.js
+++ b/test/Schema.js
@@ -987,6 +987,47 @@ describe('Schema tests', function (){
     });
   });
 
+  it('Parses document types to DynamoDB with nested maps within maps when saveUnknown=true and useDocumentTypes=true', async function () {
+
+    var schema = new Schema({
+      id: Number,
+      anotherMap: Map,
+    }, {
+      saveUnknown: true
+    });
+
+    var model = {
+      id: 2,
+      anotherMap: {
+        test1: {
+          name: 'Bob'
+        },
+        test2: {
+          name: 'Smith'
+        }
+      }
+    };
+    const result = await schema.toDynamo(model);
+
+    result.should.eql({
+      id: { N: '2' },
+      anotherMap: {
+        M: {
+          test1: {
+            M: {
+              name: { S: 'Bob' },
+            }
+          },
+          test2: {
+            M: {
+              name: { S: 'Smith' },
+            }
+          }
+        }
+      }
+    });
+  });
+
   it('Handle unknown attributes in DynamoDB', async function () {
 
     var unknownSchema = new Schema({


### PR DESCRIPTION
### Summary:

This PR fixes an issue with nested maps toDynamo when saveUnknown is true.


### GitHub linked issue:

Closes #323 


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
