### PR TITLE
Moving semantic release dependencies to dev-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
   "devDependencies": {
     "@commitlint/cli": "7.5.1",
     "@commitlint/config-conventional": "7.5.0",
+    "@semantic-release/commit-analyzer": "6.1.0",
+    "@semantic-release/release-notes-generator": "7.1.4",
     "@semantic-release/changelog": "3.0.2",
     "@semantic-release/git": "7.0.8",
     "@semantic-release/github": "5.2.10",
@@ -72,8 +74,6 @@
     "should": "13.2.3"
   },
   "dependencies": {
-    "@semantic-release/commit-analyzer": "6.1.0",
-    "@semantic-release/release-notes-generator": "7.1.4",
     "aws-sdk": "2.395.0",
     "debug": "4.1.1",
     "deep-equal": "1.0.1",


### PR DESCRIPTION
### Summary:

Moving the semantic release dependencies to dev-dependencies.


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
