### PR TITLE
Fix: Stop timestamp conditions being overwritten

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,7 +31,7 @@ module.exports = {
     'max-statements': ['error', {'max': 130}],
     'max-lines': ['error', {'max': 3600}],
     'complexity': ['error', {'max': 75}],
-    'max-lines-per-function': ['error', {'max': 3500}],
+    'max-lines-per-function': ['error', {'max': 3600}],
     'max-statements-per-line': ['error', {'max': 6}],
     'max-depth': ['error', {'max': 7}],
     'max-len': ['error', {'code': 351}],

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -24,7 +24,7 @@ function Model (obj) {
   }
 }
 
-async function processCondition (req, options, schema) {
+async function processCondition (req, options, model) {
   if (options.condition) {
     if (req.ConditionExpression) {
       req.ConditionExpression = `(${req.ConditionExpression}) and (${options.condition})`;
@@ -45,9 +45,9 @@ async function processCondition (req, options, schema) {
         const k = keys[i];
 
         const val = options.conditionValues[k];
-        const attr = schema.attributes[k];
+        const attr = model.$__.schema.attributes[k];
         if (attr) {
-          req.ExpressionAttributeValues[`:${k}`] = await attr.toDynamo(val);
+          req.ExpressionAttributeValues[`:${k}`] = await attr.toDynamo(val, undefined, model, {'updateTimestamps': false});
         } else {
           throw new errors.ModelError(`Invalid condition value: ${k}. The name must either be in the schema or a full DynamoDB object must be specified.`);
         }
@@ -419,7 +419,7 @@ Model.conditionCheck = async function (NewModel, key, options, next) {
       const rangeKeyName = schema.rangeKey.name;
       conditionReq.Key[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName], undefined, key);
     }
-    await processCondition(conditionReq, options, schema);
+    await processCondition(conditionReq, options, NewModel);
 
     debug('Condition Check', conditionReq);
     deferred.resolve(conditionReq);
@@ -488,7 +488,7 @@ Model.prototype.put = async function (options, next) {
         item.ExpressionAttributeNames['#__hash_key'] = schema.hashKey.name;
       }
     }
-    await processCondition(item, options, schema);
+    await processCondition(item, options, this);
 
     debug('putItem', item);
 
@@ -776,7 +776,7 @@ Model.update = async function (NewModel, key, update, options, next) {
     'ExpressionAttributeValues': {},
     'ReturnValues': options.returnValues
   };
-  await processCondition(updateReq, options, NewModel.$__.schema);
+  await processCondition(updateReq, options, NewModel);
 
   updateReq.Key[hashKeyName] = await schema.hashKey.toDynamo(key[hashKeyName], undefined, key);
 

--- a/test/Model.js
+++ b/test/Model.js
@@ -885,6 +885,34 @@ describe('Model', function () {
     });
   });
 
+  it('should save without updating timestamps in conditions', (done) => {
+    const myCat = new Cats.Cat9({
+      'id': 1,
+      'name': 'Fluffy',
+      'vet': {'name': 'theVet', 'address': '12 somewhere'},
+      'ears': [{'name': 'left'}, {'name': 'right'}],
+      'legs': ['front right', 'front left', 'back right', 'back left'],
+      'more': {'favorites': {'food': 'fish'}},
+      'array': [{'one': '1'}],
+      'validated': 'valid'
+    });
+
+    myCat.save((err, theSavedCat1) => {
+      const savedUpdatedAt = theSavedCat1.updatedAt;
+
+      myCat.name = 'FluffyB';
+      myCat.save({
+        'condition': 'updatedAt = :updatedAt',
+        'conditionValues': {
+          'updatedAt': savedUpdatedAt
+        }
+      }, (error) => {
+        should(error).eql(null);
+        done();
+      });
+    });
+  });
+
 
   it('Save existing item with updating expires', (done) => {
     const myCat = new Cats.Cat11({


### PR DESCRIPTION
Condition values referencing timestamps could be overwritten by both
when either updateTimestamps flag was on or by the set method. This
would cause conditions to fail.

The change disables these modification paths in `Attribute.toDynamo` for
condition values.

### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
