### PR TITLE
fix(model): allows string for array attribute in contains condition

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -47,7 +47,8 @@ async function processCondition (req, options, model) {
         const val = options.conditionValues[k];
         const attr = model.$__.schema.attributes[k];
         if (attr) {
-          req.ExpressionAttributeValues[`:${k}`] = await attr.toDynamo(val, undefined, model, {'updateTimestamps': false});
+          const noSet = options.condition.startsWith('contains');
+          req.ExpressionAttributeValues[`:${k}`] = await attr.toDynamo(val, noSet, model, {'updateTimestamps': false});
         } else {
           throw new errors.ModelError(`Invalid condition value: ${k}. The name must either be in the schema or a full DynamoDB object must be specified.`);
         }

--- a/test/Model.js
+++ b/test/Model.js
@@ -2425,6 +2425,39 @@ describe('Model', function () {
         done();
       });
     });
+
+    it('Allows simple string for array attribute in contains condition', (done) => {
+      const kitten = new Cats.Cat(
+        {
+          'id': 1,
+          'name': 'Fluffy',
+          'legs': ['front right', 'front left', 'back right', 'back left']
+        }
+      );
+
+      kitten.save(() => {
+        const updateOptions = {
+          'condition': 'contains(legs, :legs)',
+          'conditionValues': {'legs': 'front right'}
+        };
+
+        Cats.Cat.update({'id': 1}, {'name': 'Puffy'}, updateOptions, (err, data) => {
+          should.not.exist(err);
+          should.exist(data);
+          data.id.should.eql(1);
+          data.name.should.equal('Puffy');
+          Cats.Cat.get(1, (errA, puffy) => {
+            should.not.exist(errA);
+            should.exist(puffy);
+            puffy.id.should.eql(1);
+            puffy.name.should.eql('Puffy');
+            done();
+          });
+        });
+      });
+
+    });
+
   });
 
   describe('Model.populate', () => {


### PR DESCRIPTION
### Summary:
When using the contains function for a conditional update, dynamoose requires the value to be an array, while it needs to be a string instead.

Dynamoose deduces from the attribute type being an array, that the value needs to be an array, too. This is not the case for the contains function. See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html

### GitHub linked issue:
Closes https://github.com/dynamoosejs/dynamoose/issues/618

### Is this ready to be merged into Dynamoose? (select 1):
- [X] Yes
- [ ] No


### Other:
- [X] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [ ] I have updated the Dynamoose documentation (if required) given the changes I made
- [X] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [X] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [X] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [X] I have filled out all fields above
