### PR TITLE
Debug casts object to string

### DIFF
--- a/lib/Schema.js
+++ b/lib/Schema.js
@@ -215,7 +215,7 @@ Schema.prototype.parseDynamo = async function (model, dynamoObj) {
     model.$__.originalItem = JSON.parse(JSON.stringify(model));
   }
 
-  debug('parseDynamo: %s', model);
+  debug('parseDynamo: %O', model);
 
   return dynamoObj;
 


### PR DESCRIPTION
### Summary:
Very tiny improvement, just a log that prints an object as a string, I doubt this is the intended behavior because it's not very useful in my opinion, literally a one character change


### Is this ready to be merged into Dynamoose? (select 1):
- [X] Yes
- [ ] No
