### PR TITLE
feat(plugin): added item prop to event object passed to model:put put:called listener.

### DIFF
--- a/docs/api/plugins.md
+++ b/docs/api/plugins.md
@@ -244,7 +244,7 @@ Dynamoose will emit this event when a put is called on a model.
 	event: {
 		options: _____, // options passed to put (object) (warning: in some cases this can be the callback function in the `put:called` stage)
 		callback: _____, // callback passed to put (function) (warning: in some cases this can be the null if options is not passed in) (only valid on `put:called`)
-		item: _____ // item that will be/has been saved to DynamoDB (function) (only valid on `request:*`)
+		item: _____ // item that will be/has been saved to DynamoDB (object) (model class instance on `put:called`, PutItem request object on `request:*`)
 		error: _____ // the error object that was received from DynamoDB (object) (only valid on `request:post`)
 	}
 	action: {

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -433,7 +433,7 @@ Model.prototype.put = async function (options, next) {
   debug('put', this);
   const deferred = Q.defer();
   const emitObjectPutCalled = {
-    'event': {'callback': next, options},
+    'event': {'callback': next, options, 'item': this},
     'actions': {
       'updateCallback' (cb) { next = cb; },
       'updateOptions' (newOptions) { options = newOptions; }

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -432,15 +432,30 @@ Model.conditionCheck = async function (NewModel, key, options, next) {
 Model.prototype.put = async function (options, next) {
   debug('put', this);
   const deferred = Q.defer();
-  const shouldContinuePutCalled = await this.$__.NewModel._emit('model:put', 'put:called', {'event': {'callback': next, options}, 'actions': {'updateCallback' (cb) { next = cb; }, 'updateOptions' (newOptions) { options = newOptions; }}}, deferred);
+  const emitObjectPutCalled = {
+    'event': {'callback': next, options},
+    'actions': {
+      'updateCallback' (cb) { next = cb; },
+      'updateOptions' (newOptions) { options = newOptions; }
+    }
+  };
+  const shouldContinuePutCalled = await this.$__.NewModel._emit('model:put', 'put:called', emitObjectPutCalled, deferred);
   if (shouldContinuePutCalled === false) { return; }
   let item;
 
   const putItem = async () => {
-    const shouldContinueRequestPre = await this.$__.NewModel._emit('model:put', 'request:pre', {'event': {options, item}, 'actions': {'updateItem' (newItem) { item = newItem; }}}, deferred);
+    const emitObjectRequestPre = {
+      'event': {options, item},
+      'actions': {'updateItem' (newItem) { item = newItem; }}
+    };
+    const shouldContinueRequestPre = await this.$__.NewModel._emit('model:put', 'request:pre', emitObjectRequestPre, deferred);
     if (shouldContinueRequestPre === false) { return; }
     this.$__.base.ddb().putItem(item, async (err) => {
-      const shouldContinueRequestPost = await this.$__.NewModel._emit('model:put', 'request:post', {'event': {options, item, 'error': err}, 'actions': {'updateError' (newErr) { err = newErr; }}}, deferred);
+      const emitObjectRequestPost = {
+        'event': {options, item, 'error': err},
+        'actions': {'updateError' (newErr) { err = newErr; }}
+      };
+      const shouldContinueRequestPost = await this.$__.NewModel._emit('model:put', 'request:post', emitObjectRequestPost, deferred);
       if (shouldContinueRequestPost === false) { return; }
       if (err) {
         deferred.reject(err);
@@ -526,7 +541,15 @@ Model.create = function (NewModel, obj, options, next) {
 Model.get = async function (NewModel, key, options, next) {
   debug('Get %j', key);
   const deferred = Q.defer();
-  const shouldContinueGetCalled = await NewModel._emit('model:get', 'get:called', {'event': {'callback': next, key, options}, 'actions': {'updateCallback' (cb) { next = cb; }, 'updateKey' (newKey) { key = newKey; }, 'updateOptions' (newOptions) { options = newOptions; }}}, deferred);
+  const emitObjectGetCalled = {
+    'event': {'callback': next, key, options},
+    'actions': {
+      'updateCallback' (cb) { next = cb; },
+      'updateKey' (newKey) { key = newKey; },
+      'updateOptions' (newOptions) { options = newOptions; }
+    }
+  };
+  const shouldContinueGetCalled = await NewModel._emit('model:get', 'get:called', emitObjectGetCalled, deferred);
   if (shouldContinueGetCalled === false) { return; }
 
   options = options || {};
@@ -589,15 +612,30 @@ Model.get = async function (NewModel, key, options, next) {
   async function get () {
     debug('getItem', getReq);
 
-    const emitEventObjectRequestPre = {'callback': next, key, options, 'getRequest': getReq};
-    const emitObjectRequestPre = {'event': emitEventObjectRequestPre, 'actions': {'updateCallback' (cb) { next = cb; }, 'updateKey' (newKey) { key = newKey; }, 'updateOptions' (newOptions) { options = newOptions; }, 'updateGetRequest' (newReq) { getReq = newReq; }}};
+    const emitObjectRequestPre = {
+      'event': {'callback': next, key, options, 'getRequest': getReq},
+      'actions': {
+        'updateCallback' (cb) { next = cb; },
+        'updateKey' (newKey) { key = newKey; },
+        'updateOptions' (newOptions) { options = newOptions; },
+        'updateGetRequest' (newReq) { getReq = newReq; }
+      }
+    };
     const shouldContinueRequestPre = await NewModel._emit('model:get', 'request:pre', emitObjectRequestPre, deferred);
     if (shouldContinueRequestPre === false) { return; }
 
     newModel$.base.ddb().getItem(getReq, async (err, data) => {
 
-      const emitEventObjectRequestPost = {'callback': next, key, options, 'error': err, data};
-      const emitObjectRequestPost = {'event': emitEventObjectRequestPost, 'actions': {'updateCallback' (cb) { next = cb; }, 'updateKey' (newKey) { key = newKey; }, 'updateOptions' (newOptions) { options = newOptions; }, 'updateError' (newErr) { err = newErr; }, 'updateData' (newData) { data = newData; }}};
+      const emitObjectRequestPost = {
+        'event': {'callback': next, key, options, 'error': err, data},
+        'actions': {
+          'updateCallback' (cb) { next = cb; },
+          'updateKey' (newKey) { key = newKey; },
+          'updateOptions' (newOptions) { options = newOptions; },
+          'updateError' (newErr) { err = newErr; },
+          'updateData' (newData) { data = newData; }
+        }
+      };
       const shouldContinueRequestPost = await NewModel._emit('model:get', 'request:post', emitObjectRequestPost, deferred);
       if (shouldContinueRequestPost === false) { return; }
 

--- a/test/Plugin.js
+++ b/test/Plugin.js
@@ -565,6 +565,42 @@ describe('Plugin', function () {
 
   });
 
+  it('Should pass emit object to put:called callback', (done) => {
+    let emitObject;
+
+    const pluginA = function (plugin) {
+      plugin.setName('Plugin A');
+      plugin.on('model:put', 'put:called', (obj) => { emitObject = obj; });
+    };
+
+
+    Model.plugin(pluginA);
+
+    const myItem = new Model(
+      {
+        'id': 1,
+        'name': 'Lucky',
+        'owner': 'Bob',
+        'age': 2
+      }
+    );
+    myItem.save({'prop': true}, () => {
+      should.exist(emitObject);
+      emitObject.should.have.keys('model', 'modelName', 'plugins', 'plugin', 'event', 'actions');
+
+      emitObject.should.have.propertyByPath('event', 'type').which.is.eql('model:put');
+      emitObject.should.have.propertyByPath('event', 'stage').which.is.eql('put:called');
+      emitObject.should.have.propertyByPath('event', 'options').match({'prop': true});
+      emitObject.should.have.propertyByPath('event', 'callback').which.is.Function;
+
+      emitObject.should.have.propertyByPath('actions', 'updateCallback').which.is.Function;
+      emitObject.should.have.propertyByPath('actions', 'updateOptions').which.is.Function;
+
+      done();
+    });
+
+  });
+
   it('Should continue for model:put request:pre', (done) => {
 
     const pluginA = function (plugin) {
@@ -619,6 +655,41 @@ describe('Plugin', function () {
     );
     myItem.save((err) => {
       err.should.eql('Test');
+
+      done();
+    });
+
+  });
+
+  it('Should pass emit object to request:pre callback', (done) => {
+    let emitObject;
+
+    const pluginA = function (plugin) {
+      plugin.setName('Plugin A');
+      plugin.on('model:put', 'request:pre', (obj) => { emitObject = obj; });
+    };
+
+
+    Model.plugin(pluginA);
+
+    const myItem = new Model(
+      {
+        'id': 1,
+        'name': 'Lucky',
+        'owner': 'Bob',
+        'age': 2
+      }
+    );
+    myItem.save({'prop': true}, () => {
+      should.exist(emitObject);
+      emitObject.should.have.keys('model', 'modelName', 'plugins', 'plugin', 'event', 'actions');
+
+      emitObject.should.have.propertyByPath('event', 'type').which.is.eql('model:put');
+      emitObject.should.have.propertyByPath('event', 'stage').which.is.eql('request:pre');
+      emitObject.should.have.propertyByPath('event', 'item').which.has.keys('Item', 'TableName');
+      emitObject.should.have.propertyByPath('event', 'options').match({'prop': true});
+
+      emitObject.should.have.propertyByPath('actions', 'updateItem').which.is.Function;
 
       done();
     });
@@ -681,6 +752,46 @@ describe('Plugin', function () {
       err.should.eql('Test');
 
       done();
+    });
+
+  });
+
+  it('Should pass emit object to request:post callback', (done) => {
+    let emitObject;
+
+    const pluginA = function (plugin) {
+      plugin.setName('Plugin A');
+      plugin.on('model:put', 'request:post', (obj) => { emitObject = obj; });
+    };
+
+
+    Model.plugin(pluginA);
+
+    const myItem = new Model(
+      {
+        'id': 1,
+        'name': 'Lucky',
+        'owner': 'Bob',
+        'age': 2
+      }
+    );
+    myItem.save({'prop': true}, () => {
+      should.exist(emitObject);
+      emitObject.should.have.keys('model', 'modelName', 'plugins', 'plugin', 'event', 'actions');
+
+      emitObject.should.have.propertyByPath('event', 'type').which.is.eql('model:put');
+      emitObject.should.have.propertyByPath('event', 'stage').which.is.eql('request:post');
+      emitObject.should.have.propertyByPath('event', 'item').which.has.keys('Item', 'TableName');
+      emitObject.should.have.propertyByPath('event', 'options').match({'prop': true});
+
+      emitObject.should.have.propertyByPath('actions', 'updateError').which.is.Function;
+
+      delete myItem.id;
+      myItem.save(() => {
+        emitObject.should.have.propertyByPath('event', 'error').which.is.not.eql(null).and.has.property('message');
+
+        done();
+      });
     });
 
   });

--- a/test/Plugin.js
+++ b/test/Plugin.js
@@ -576,20 +576,20 @@ describe('Plugin', function () {
 
     Model.plugin(pluginA);
 
-    const myItem = new Model(
-      {
-        'id': 1,
-        'name': 'Lucky',
-        'owner': 'Bob',
-        'age': 2
-      }
-    );
+    const data = {
+      'id': 1,
+      'name': 'Lucky',
+      'owner': 'Bob',
+      'age': 2
+    };
+    const myItem = new Model(data);
     myItem.save({'prop': true}, () => {
       should.exist(emitObject);
       emitObject.should.have.keys('model', 'modelName', 'plugins', 'plugin', 'event', 'actions');
 
       emitObject.should.have.propertyByPath('event', 'type').which.is.eql('model:put');
       emitObject.should.have.propertyByPath('event', 'stage').which.is.eql('put:called');
+      emitObject.should.have.propertyByPath('event', 'item').match(data);
       emitObject.should.have.propertyByPath('event', 'options').match({'prop': true});
       emitObject.should.have.propertyByPath('event', 'callback').which.is.Function;
 


### PR DESCRIPTION
<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->


### Summary:
I've added an additional prop to the event object that is passed to plugin callbacks during `put:called` stage of  `model:put` event. The prop is `item` and it is equal to the model class instance that is being put into the database. I need this for the [optimistic locking plugin](https://github.com/dynamoosejs/dynamoose-plugin-ideas/issues/3), and I imagine it can be useful to other plugin creators as well. One use case is if we want to get updatedAt timestamp of the item being saved before the timestamp gets updated by Dynamoose.


<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->


<!-- Please remove the `Other information` section below if it doesn't apply to this PR -->
### Other information:
As I was modifying the code I split `NewModel._emit()` call statements into multiple lines for better readability, and updated style of every statement so that they match. Hopefully you will find this tiny change useful. I also threw in extra tests for emit object properties for every stage of the `model:put` event.

### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
