### PR TITLE
Update query.md

### DIFF
--- a/docs/api/query.md
+++ b/docs/api/query.md
@@ -1,4 +1,4 @@
-### Model.query(query, options, callback)
+### Model.query(query, callback)
 
 Queries a table or index. The query parameter can either be the hash key of the table or global index or a complete query object. If the callback is provided, the exec command is called automatically, and the query parameter must be a query object.
 
@@ -16,7 +16,7 @@ Dog.query({breed: {eq: 'Beagle'}}, function (err, dogs) {
 });
 ```
 
-### Model.queryOne(query, options, callback)
+### Model.queryOne(query, callback)
 
 Queries a table or index, sets [`query.limit`](#querylimitlimit) to `1`.
 


### PR DESCRIPTION
Remove `query` and `queryOne` typedef reference to nonexistent `options` object.

<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->


### Summary:
Removing as `options` isn't described in docs or implemented in type definitions.


<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->
Closes #631 

### Is this ready to be merged into Dynamoose? (select 1):
- [X] Yes
- [ ] No


### Other:
- [X] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [X] I have updated the Dynamoose documentation (if required) given the changes I made
- [X] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [X] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [X] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [X] I have filled out all fields above
