### PR TITLE
fix(types): added streamOptions to ModelOption

### DIFF
--- a/dynamoose.d.ts
+++ b/dynamoose.d.ts
@@ -39,6 +39,10 @@ declare module "dynamoose" {
     waitForActiveTimeout?: number, // wait 3 minutes for table to activate
     prefix?: string, // Set table name prefix
     suffix?: string, // Set table name suffix
+    streamOptions?: { // Set table stream options
+      enabled: boolean, // Enable/disable stream
+      type: 'NEW_IMAGE'|'OLD_IMAGE'|'NEW_AND_OLD_IMAGES'|'KEYS_ONLY', // https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_StreamSpecification.html#DDB-Type-StreamSpecification-StreamViewType
+    },
     serverSideEncryption?: boolean, // Set SSESpecification.Enabled (server-side encryption) to true or false (default: true)
   }
 


### PR DESCRIPTION
<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->


### Summary:
Dynamoose typings file does not include `streamOptions` field inside `ModelOption` interface, which is used for model options supplied to `dynamoose.model()`. This PR adds that field.

#634 is already adding that field, but is using obscure `object` type instead, which can lead to runtime errors.

### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [ ] I have updated the Dynamoose documentation (if required) given the changes I made
- [ ] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
