### PR TITLE
feat(schema): change the way attributes are set by parseDynamo function

### DIFF
--- a/lib/Schema.js
+++ b/lib/Schema.js
@@ -219,7 +219,7 @@ Schema.prototype.parseDynamo = async function (model, dynamoObj) {
         attrVal = await attr.parseDynamo(dynamoObj[name]);
       }
       if (attrVal !== undefined && attrVal !== null) {
-        model[name] = attrVal;
+        model[attr.name] = attrVal;
       }
     } else {
       debug('parseDynamo: received an attribute name (%s) that is not defined in the schema', name);


### PR DESCRIPTION
<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->


### Summary:
This does not change `parseDynamo` result 99% of the time, because `name` and `attr.name` are usually identical, but makes it possible to manually add hidden attributes to a schema by calling `Attribute.create()` with `name` set to `Symbol()`, which can be useful to plugin authors.



<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:
```js
plugin.on('plugin', 'init', ({ model }) => {
  const { schema: originalSchema } = model.$__;

  const schema = Object.create(Object.getPrototypeOf(originalSchema));
  Object.assign(schema, originalSchema);
  schema.attributes['hidden'] = Attribute.create(schema, Symbol('hidden'), { type: Number });
  Object.assign(model.$__, { schema });
});
```


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [ ] I have updated the Dynamoose documentation (if required) given the changes I made
- [ ] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
