### PR TITLE
Emit 'batchPut' and 'update' plugin events

### DIFF
--- a/docs/api/plugins.md
+++ b/docs/api/plugins.md
@@ -273,13 +273,48 @@ Dynamoose will emit this event when a batchPut is called on a model.
 	event: {
 		options: _____, // options passed to batchPut (object) (warning: in some cases this can be the callback function in the `batchput:called` stage)
 		callback: _____, // callback passed to batchPut (function) (warning: in some cases this can be the null if options is not passed in) (only valid on `batchput:called`)
-		items: _____ // items that will be/has been saved to DynamoDB (object) (model class instances on `batchput:called`, BatchWriteItem batched requests on `request:pre`, flattened BatchWriteItem responses on `request:post`)
+		items: _____, // items that will be/has been saved to DynamoDB (object) (model class instances on `batchput:called`, BatchWriteItem batched requests on `request:pre`, flattened BatchWriteItem responses on `request:post`)
 		error: _____ // the error object that was received from DynamoDB (object) (only valid on `request:post`)
-	}
+	},
 	action: {
-		updateCallback: _____ // function to update callback that is called (fn: function) (only valid on `batchput:called`)
-		updateOptions: _____ // function to update options object (reqObj: object) (only valid on `batchput:called`)
-		updateItems: _____ // function to update data that will be sent to DynamoDB (dataObj: object) (only valid on `request:pre`)
+		updateCallback: _____, // function to update callback that is called (fn: function) (only valid on `batchput:called`)
+		updateOptions: _____, // function to update options object (reqObj: object) (only valid on `batchput:called`)
+		updateItems: _____, // function to update data that will be sent to DynamoDB (dataObj: object) (only valid on `request:pre`)
+		updateError: _____ // function to update error that was received from DynamoDB query before proceeding (errorObj: object) (only valid on `request:post`)
+	}
+}
+```
+
+#### `model:update`
+
+Dynamoose will emit this event when an update is called on a model.
+
+##### Stages
+
+- `update:called` - Dynamoose will emit this stage when an update is about to start
+- `request:pre` - Dynamoose will emit this stage when an update request is about to be made to DynamoDB
+- `request:post` - Dynamoose will emit this stage when an update request response has been received from DynamoDB
+
+##### Additional Items Added to Object
+
+```
+{
+	event: {
+		options: _____, // options passed to update (object)
+		key: _____, // key of item that will be updated in DynamoDB (object)
+		callback: _____, // callback passed to update (function) (only valid on `update:called`)
+		expression: _____, // Update Expression that will be sent to DynamoDB (object) (only valid on `update:called`)
+		request: _____, // Update Request that will be sent to DynamoDB (object) (only valid on `request:pre`)
+		data: _____, // Update Request response that was received from DynamoDB (object) (only valid on `request:post`)
+		error: _____ // the error object that was received from DynamoDB (object) (only valid on `request:post`)
+	},
+	action: {
+		updateCallback: _____, // function to update callback that is called (fn: function) (only valid on `update:called`)
+		updateOptions: _____, // function to update options object (object) (only valid on `update:called`)
+		updateKey: _____, // function to update key of item that will be updated in DynamoDB (object) (only valid on `update:called`)
+		updateExpression: _____, // function to update Update Expression that will be sent to DynamoDB (object) (only valid on `update:called`)
+		updateRequest: _____, // function to update Update Request that will be sent to DynamoDB (object) (only valid on `request:pre`)
+		updateData: _____, // function to update Update Request response that was received from DynamoDB (object) (only valid on `request:post`)
 		updateError: _____ // function to update error that was received from DynamoDB query before proceeding (errorObj: object) (only valid on `request:post`)
 	}
 }

--- a/docs/api/plugins.md
+++ b/docs/api/plugins.md
@@ -255,3 +255,32 @@ Dynamoose will emit this event when a put is called on a model.
 	}
 }
 ```
+
+#### `model:batchput`
+
+Dynamoose will emit this event when a batchPut is called on a model.
+
+##### Stages
+
+- `batchput:called` - Dynamoose will emit this stage when a batchPut is about to start
+- `request:pre` - Dynamoose will emit this stage when a batchPut request is about to be made to DynamoDB
+- `request:post` - Dynamoose will emit this stage when a batchPut request response has been received from DynamoDB
+
+##### Additional Items Added to Object
+
+```
+{
+	event: {
+		options: _____, // options passed to batchPut (object) (warning: in some cases this can be the callback function in the `batchput:called` stage)
+		callback: _____, // callback passed to batchPut (function) (warning: in some cases this can be the null if options is not passed in) (only valid on `batchput:called`)
+		items: _____ // items that will be/has been saved to DynamoDB (object) (model class instances on `batchput:called`, BatchWriteItem batched requests on `request:pre`, flattened BatchWriteItem responses on `request:post`)
+		error: _____ // the error object that was received from DynamoDB (object) (only valid on `request:post`)
+	}
+	action: {
+		updateCallback: _____ // function to update callback that is called (fn: function) (only valid on `batchput:called`)
+		updateOptions: _____ // function to update options object (reqObj: object) (only valid on `batchput:called`)
+		updateItems: _____ // function to update data that will be sent to DynamoDB (dataObj: object) (only valid on `request:pre`)
+		updateError: _____ // function to update error that was received from DynamoDB query before proceeding (errorObj: object) (only valid on `request:post`)
+	}
+}
+```

--- a/docs/api/plugins.md
+++ b/docs/api/plugins.md
@@ -271,8 +271,8 @@ Dynamoose will emit this event when a batchPut is called on a model.
 ```
 {
 	event: {
-		options: _____, // options passed to batchPut (object) (warning: in some cases this can be the callback function in the `batchput:called` stage)
-		callback: _____, // callback passed to batchPut (function) (warning: in some cases this can be the null if options is not passed in) (only valid on `batchput:called`)
+		options: _____, // options passed to batchPut (object)
+		callback: _____, // callback passed to batchPut (function) (only valid on `batchput:called`)
 		items: _____, // items that will be/has been saved to DynamoDB (object) (model class instances on `batchput:called`, BatchWriteItem batched requests on `request:pre`, flattened BatchWriteItem responses on `request:post`)
 		error: _____ // the error object that was received from DynamoDB (object) (only valid on `request:post`)
 	},

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -1527,6 +1527,17 @@ Model.batchPut = async function (NewModel, items, options, next) {
   debug('BatchPut %j', items);
   const deferred = Q.defer();
 
+  options = options || {};
+  if (typeof options === 'function') {
+    next = options;
+    options = {};
+  }
+
+  if (!Array.isArray(items)) {
+    deferred.reject(new errors.ModelError('batchPut requires items to be an array'));
+    return deferred.promise.nodeify(next);
+  }
+
   const emitObjectBatchPutCalled = {
     'event': {'callback': next, options, items},
     'actions': {
@@ -1535,17 +1546,7 @@ Model.batchPut = async function (NewModel, items, options, next) {
     }
   };
   const shouldContinueBatchPutCalled = await NewModel._emit('model:batchput', 'batchput:called', emitObjectBatchPutCalled, deferred);
-  if (shouldContinueBatchPutCalled === false) { return; }
-
-  if (!Array.isArray(items)) {
-    deferred.reject(new errors.ModelError('batchPut requires items to be an array'));
-    return deferred.promise.nodeify(next);
-  }
-  options = options || {};
-  if (typeof options === 'function') {
-    next = options;
-    options = {};
-  }
+  if (shouldContinueBatchPutCalled === false) { return deferred.promise.nodeify(next); }
 
   const {schema} = NewModel.$__;
   const newModel$ = NewModel.$__;

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -761,6 +761,19 @@ Model.update = async function (NewModel, key, update, options, next) {
     options = {};
   }
 
+  // emit update:called stage of model:update event
+  const emitObjectUpdateCalled = {
+    'event': {'callback': next, 'expression': update, options, key},
+    'actions': {
+      'updateCallback' (cb) { next = cb; },
+      'updateExpression' (newExpression) { update = newExpression; },
+      'updateOptions' (newOptions) { options = newOptions; },
+      'updateKey' (newKey) { key = newKey; }
+    }
+  };
+  const shouldContinueUpdateCalled = await NewModel._emit('model:update', 'update:called', emitObjectUpdateCalled, deferred);
+  if (shouldContinueUpdateCalled === false) { return; }
+
   // default createRequired to false
   if (typeof options.createRequired === 'undefined') {
     options.createRequired = false;
@@ -810,7 +823,7 @@ Model.update = async function (NewModel, key, update, options, next) {
     key[hashKeyName] = keyVal;
   }
 
-  const updateReq = {
+  let updateReq = {
     'TableName': NewModel.$__.name,
     'Key': {},
     'ExpressionAttributeNames': {},
@@ -1103,9 +1116,28 @@ Model.update = async function (NewModel, key, update, options, next) {
 
   const newModel$ = NewModel.$__;
 
-  function updateItem () {
+  async function updateItem () {
     debug('updateItem', updateReq);
+
+    // emit request:pre stage of model:update event
+    const emitObjectRequestPre = {
+      'event': {options, key, 'request': updateReq},
+      'actions': {'updateRequest' (request) { updateReq = request; }}
+    };
+    const shouldContinueRequestPre = await NewModel._emit('model:update', 'request:pre', emitObjectRequestPre, deferred);
+    if (shouldContinueRequestPre === false) { return; }
+
     newModel$.base.ddb().updateItem(updateReq, async (err, data) => {
+      const emitObjectRequestPost = {
+        'event': {options, key, data, 'error': err},
+        'actions': {
+          'updateData' (newData) { data = newData; },
+          'updateError' (newErr) { err = newErr; }
+        }
+      };
+      const shouldContinueRequestPost = await NewModel._emit('model:update', 'request:post', emitObjectRequestPost, deferred);
+      if (shouldContinueRequestPost === false) { return; }
+
       if (err) {
         debug('Error returned by updateItem', err);
         return deferred.reject(err);

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -1495,6 +1495,16 @@ Model.batchPut = async function (NewModel, items, options, next) {
   debug('BatchPut %j', items);
   const deferred = Q.defer();
 
+  const emitObjectBatchPutCalled = {
+    'event': {'callback': next, options, items},
+    'actions': {
+      'updateCallback' (cb) { next = cb; },
+      'updateOptions' (newOptions) { options = newOptions; }
+    }
+  };
+  const shouldContinueBatchPutCalled = await NewModel._emit('model:batchput', 'batchput:called', emitObjectBatchPutCalled, deferred);
+  if (shouldContinueBatchPutCalled === false) { return; }
+
   if (!Array.isArray(items)) {
     deferred.reject(new errors.ModelError('batchPut requires items to be an array'));
     return deferred.promise.nodeify(next);
@@ -1519,12 +1529,30 @@ Model.batchPut = async function (NewModel, items, options, next) {
     }
   }));
 
-  const batchPut = function () {
-    batchWriteItems(NewModel, batchRequests).then((result) => {
-      deferred.resolve(result);
-    }).fail((err) => {
-      deferred.reject(err);
-    });
+  const batchPut = async function () {
+    const emitObjectRequestPre = {
+      'event': {options, 'items': batchRequests},
+      'actions': {'updateItems' (newItems) { items = newItems; }}
+    };
+    const shouldContinueRequestPre = await NewModel._emit('model:batchput', 'request:pre', emitObjectRequestPre, deferred);
+    if (shouldContinueRequestPre === false) { return; }
+
+    const batchWriteCb = async (result, err) => {
+      const emitObjectRequestPost = {
+        'event': {options, 'items': result, 'error': err},
+        'actions': {'updateError' (newErr) { err = newErr; }}
+      };
+      const shouldContinueRequestPost = await NewModel._emit('model:batchput', 'request:post', emitObjectRequestPost, deferred);
+      if (shouldContinueRequestPost === false) { return; }
+
+      if (err) {
+        deferred.reject(err);
+      } else {
+        deferred.resolve(result);
+      }
+    };
+
+    batchWriteItems(NewModel, batchRequests).then(batchWriteCb).fail((err) => batchWriteCb(null, err));
   };
 
   if (newModel$.options.waitForActive) {

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -772,7 +772,7 @@ Model.update = async function (NewModel, key, update, options, next) {
     }
   };
   const shouldContinueUpdateCalled = await NewModel._emit('model:update', 'update:called', emitObjectUpdateCalled, deferred);
-  if (shouldContinueUpdateCalled === false) { return; }
+  if (shouldContinueUpdateCalled === false) { return deferred.promise.nodeify(next); }
 
   // default createRequired to false
   if (typeof options.createRequired === 'undefined') {

--- a/test/Plugin.js
+++ b/test/Plugin.js
@@ -1195,6 +1195,49 @@ describe('Plugin', function () {
     counter.should.eql(3);
   });
 
+  it('Should continue for model:update update:called', async () => {
+    const pluginA = function (plugin) {
+      plugin.setName('Plugin A');
+      plugin.on('model:update', 'update:called', () => new Promise((resolve) => {
+        setTimeout(() => {
+          resolve({'resolve': 'Test'});
+        }, 500);
+      }));
+    };
+    Model.plugin(pluginA);
+
+    await Model.create({
+      'id': 4,
+      'name': 'Oliver',
+      'owner': 'Bill',
+      'age': 1
+    });
+    const result = await Model.update({'id': 4}, {'$ADD': {'age': 1}}, {'prop': true});
+
+    result.should.eql('Test');
+  });
+
+  it('Should not continue for model:update update:called', async () => {
+    const pluginA = function (plugin) {
+      plugin.setName('Plugin A');
+      plugin.on('model:update', 'update:called', () => new Promise((resolve) => {
+        setTimeout(() => {
+          resolve({'reject': new Error('Test')});
+        }, 500);
+      }));
+    };
+    Model.plugin(pluginA);
+
+    await Model.create({
+      'id': 5,
+      'name': 'Daisy',
+      'owner': 'Veronica',
+      'age': 1
+    });
+
+    await Model.update({'id': 5}, {'$ADD': {'age': 1}}, {'prop': true}).should.be.rejectedWith('Test');
+  });
+
   it('Should pass emit object to update:called callback', async () => {
     let emitObject;
 
@@ -1205,19 +1248,19 @@ describe('Plugin', function () {
     Model.plugin(pluginA);
 
     await Model.create({
-      'id': 4,
+      'id': 6,
       'name': 'Rex',
       'owner': 'Mike',
       'age': 1
     });
-    await Model.update({'id': 4}, {'$ADD': {'age': 1}}, {'prop': true});
+    await Model.update({'id': 6}, {'$ADD': {'age': 1}}, {'prop': true});
 
     should.exist(emitObject);
     emitObject.should.have.keys('model', 'modelName', 'plugins', 'plugin', 'event', 'actions');
 
     emitObject.should.have.propertyByPath('event', 'type').which.is.eql('model:update');
     emitObject.should.have.propertyByPath('event', 'stage').which.is.eql('update:called');
-    emitObject.should.have.propertyByPath('event', 'key').match({'id': 4});
+    emitObject.should.have.propertyByPath('event', 'key').match({'id': 6});
     emitObject.should.have.propertyByPath('event', 'expression').match({'$ADD': {'age': 1}});
     emitObject.should.have.propertyByPath('event', 'options').match({'prop': true});
     emitObject.should.have.propertyByPath('event', 'callback').which.is.Function;
@@ -1240,12 +1283,12 @@ describe('Plugin', function () {
     Model.plugin(pluginA);
 
     await Model.create({
-      'id': 5,
+      'id': 7,
       'name': 'Duke',
       'owner': 'Maria',
       'age': 1
     });
-    const result = await Model.update({'id': 5}, {'$ADD': {'age': 1}}, {'prop': true});
+    const result = await Model.update({'id': 7}, {'$ADD': {'age': 1}}, {'prop': true});
 
     result.should.eql('Test');
   });
@@ -1262,13 +1305,13 @@ describe('Plugin', function () {
     Model.plugin(pluginA);
 
     await Model.create({
-      'id': 6,
+      'id': 8,
       'name': 'Lucy',
       'owner': 'Piper',
       'age': 2
     });
 
-    await Model.update({'id': 6}, {'$ADD': {'age': 1}}, {'prop': true}).should.be.rejectedWith('Test');
+    await Model.update({'id': 8}, {'$ADD': {'age': 1}}, {'prop': true}).should.be.rejectedWith('Test');
   });
 
   it('Should pass emit object to model:update request:pre callback', async () => {
@@ -1281,12 +1324,12 @@ describe('Plugin', function () {
     Model.plugin(pluginA);
 
     await Model.create({
-      'id': 7,
+      'id': 9,
       'name': 'Ollie',
       'owner': 'Chris',
       'age': 2
     });
-    await Model.update({'id': 7}, {'$ADD': {'age': 1}}, {'prop': true});
+    await Model.update({'id': 9}, {'$ADD': {'age': 1}}, {'prop': true});
 
     should.exist(emitObject);
     emitObject.should.have.keys('model', 'modelName', 'plugins', 'plugin', 'event', 'actions');
@@ -1294,7 +1337,7 @@ describe('Plugin', function () {
     emitObject.should.have.propertyByPath('event', 'type').which.is.eql('model:update');
     emitObject.should.have.propertyByPath('event', 'stage').which.is.eql('request:pre');
     emitObject.should.have.propertyByPath('event', 'options').match({'prop': true});
-    emitObject.should.have.propertyByPath('event', 'key').match({'id': 7});
+    emitObject.should.have.propertyByPath('event', 'key').match({'id': 9});
     emitObject.should.have.propertyByPath('event', 'request').which.has.keys('TableName', 'Key', 'ExpressionAttributeNames', 'ExpressionAttributeValues', 'ReturnValues', 'UpdateExpression');
 
     const {UpdateExpression, ExpressionAttributeNames, ExpressionAttributeValues} = emitObject.event.request;
@@ -1318,12 +1361,12 @@ describe('Plugin', function () {
     Model.plugin(pluginA);
 
     await Model.create({
-      'id': 8,
+      'id': 10,
       'name': 'Louie',
       'owner': 'Nick',
       'age': 1
     });
-    const result = await Model.update({'id': 8}, {'$ADD': {'age': 1}}, {'prop': true});
+    const result = await Model.update({'id': 10}, {'$ADD': {'age': 1}}, {'prop': true});
 
     result.should.eql('Test');
   });
@@ -1340,13 +1383,13 @@ describe('Plugin', function () {
     Model.plugin(pluginA);
 
     await Model.create({
-      'id': 9,
+      'id': 11,
       'name': 'Sophie',
       'owner': 'Irene',
       'age': 1
     });
 
-    await Model.update({'id': 9}, {'$ADD': {'age': 1}}, {'prop': true}).should.be.rejectedWith('Test');
+    await Model.update({'id': 11}, {'$ADD': {'age': 1}}, {'prop': true}).should.be.rejectedWith('Test');
   });
 
   it('Should pass emit object to model:update request:post callback', async () => {
@@ -1359,12 +1402,12 @@ describe('Plugin', function () {
     Model.plugin(pluginA);
 
     await Model.create({
-      'id': 10,
+      'id': 12,
       'name': 'Tucker',
       'owner': 'Jeff',
       'age': 1
     });
-    await Model.update({'id': 10}, {'$ADD': {'age': 1}}, {'prop': true});
+    await Model.update({'id': 12}, {'$ADD': {'age': 1}}, {'prop': true});
 
     should.exist(emitObject);
     emitObject.should.have.keys('model', 'modelName', 'plugins', 'plugin', 'event', 'actions');
@@ -1372,14 +1415,14 @@ describe('Plugin', function () {
     emitObject.should.have.propertyByPath('event', 'type').which.is.eql('model:update');
     emitObject.should.have.propertyByPath('event', 'stage').which.is.eql('request:post');
     emitObject.should.have.propertyByPath('event', 'options').match({'prop': true});
-    emitObject.should.have.propertyByPath('event', 'key').match({'id': 10});
+    emitObject.should.have.propertyByPath('event', 'key').match({'id': 12});
     emitObject.should.have.propertyByPath('event', 'data').which.has.keys('Attributes');
     emitObject.should.have.propertyByPath('event', 'data', 'Attributes').which.has.keys('owner', 'name', 'id', 'age');
 
     emitObject.should.have.propertyByPath('actions', 'updateError').which.is.Function;
     emitObject.should.have.propertyByPath('actions', 'updateData').which.is.Function;
 
-    await Model.update({'id': 10}, {'$ADD': {'age': 1}}, {'condition': 'attr_not_exists(age)'}).should.be.rejected();
+    await Model.update({'id': 12}, {'$ADD': {'age': 1}}, {'condition': 'attr_not_exists(age)'}).should.be.rejected();
 
     emitObject.should.have.propertyByPath('event', 'error').which.is.not.eql(null).and.has.property('message');
   });

--- a/test/Plugin.js
+++ b/test/Plugin.js
@@ -824,6 +824,79 @@ describe('Plugin', function () {
 
   });
 
+  it('Should continue for model:batchput batchput:called', (done) => {
+
+    const pluginA = function (plugin) {
+      plugin.setName('Plugin A');
+      plugin.on('model:batchput', 'batchput:called', () => new Promise((resolve) => {
+        setTimeout(() => {
+          resolve({'resolve': 'Test'});
+        }, 500);
+      }));
+    };
+
+
+    Model.plugin(pluginA);
+
+
+    const items = [
+      {
+        'id': 1,
+        'name': 'Lucky',
+        'owner': 'Bob',
+        'age': 2
+      },
+      {
+        'id': 2,
+        'name': 'Pharaoh',
+        'owner': 'Jack',
+        'age': 5
+      }
+    ];
+    Model.batchPut(items, (err, result) => {
+      result.should.eql('Test');
+
+      done();
+    });
+
+  });
+
+  it('Should not continue for model:batchput batchput:called', (done) => {
+
+    const pluginA = function (plugin) {
+      plugin.setName('Plugin A');
+      plugin.on('model:batchput', 'batchput:called', () => new Promise((resolve) => {
+        setTimeout(() => {
+          resolve({'reject': 'Test'});
+        }, 500);
+      }));
+    };
+
+
+    Model.plugin(pluginA);
+
+    const items = [
+      {
+        'id': 1,
+        'name': 'Lucky',
+        'owner': 'Bob',
+        'age': 2
+      },
+      {
+        'id': 2,
+        'name': 'Pharaoh',
+        'owner': 'Jack',
+        'age': 5
+      }
+    ];
+    Model.batchPut(items, (err) => {
+      err.should.eql('Test');
+
+      done();
+    });
+
+  });
+
   it('Should pass emit object to batchput:called callback', (done) => {
     let emitObject;
 


### PR DESCRIPTION
<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->


### Summary:
Adds missing batchPut and update events to Plugin API, as mentioned in #325.



<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->


<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->
#565 


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
