### PR TITLE
Scan using index

### DIFF
--- a/docs/api/scan.md
+++ b/docs/api/scan.md
@@ -157,3 +157,11 @@ If you used a filter in the scan, then `count` is the number of items returned a
 ### scan.consistent()
 
 Scan with consistent read.
+
+### scan.using(index)
+
+Scan can be performed on a [sparse index](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/bp-indexes-general-sparse-indexes.html) instead of the entire table. To scan an index you have to manually specify which index to use by adding the `scan.using` method to your scan chain. The string you pass into the `scan.using` method must match the name of an index on your table. Unlike query, this method is required for index scanning.
+
+```js
+Dog.scan().using('BreedRangeIndex').where('breed').beginsWith('Sp')
+```

--- a/lib/Scan.js
+++ b/lib/Scan.js
@@ -181,6 +181,11 @@ Scan.prototype.exec = async function (next) {
     scanReq.ConsistentRead = true;
   }
 
+  if (options.indexName) {
+    debug('using index: %s', this.options.indexName);
+    scanReq.IndexName = this.options.indexName;
+  }
+
 
   function scanSegment (segment) {
     const deferred = Q.defer();
@@ -558,6 +563,11 @@ Scan.prototype.count = function () {
 Scan.prototype.counts = function () {
   this.options.counts = true;
   this.options.select = 'COUNT';
+  return this;
+};
+
+Scan.prototype.using = function (indexName) {
+  this.options.indexName = indexName;
   return this;
 };
 

--- a/test/Scan.js
+++ b/test/Scan.js
@@ -892,4 +892,33 @@ describe('Scan', function () {
     const updatedFilterRecords = await Lion.scan(updatedFilter).all(0).exec();
     updatedFilterRecords.length.should.eql(10);
   });
+
+  it('Scan using sparse index', async () => {
+    const Lion = dynamoose.model('Lion2', {
+      'id': {
+        'type': String,
+        'hashKey': true,
+        'trim': true
+      },
+      'indexId': {
+        'type': String,
+        'index': {
+          'name': 'sparseIndex',
+          'global': true
+        }
+      }
+    });
+
+    for (let i = 0; i < 10; i += 1) {
+      const record = {'id': `${i}`};
+      if (i % 3 === 0) {
+        record.indexId = record.id;
+      }
+
+      await new Lion(record).save();
+    }
+
+    const allIndexRecords = await Lion.scan().using('sparseIndex').exec();
+    allIndexRecords.length.should.eql(4);
+  });
 });


### PR DESCRIPTION
<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->


### Summary:
Minimal implementation of `Scan.using()`. I did not implement the whole inference logic, so for now scanning an index requires explicitly calling `using(indexName)`. Hopefully that's fine for now.


<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->
Closes #211 


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
