### PR TITLE
feat: support multi-model single table

### DIFF
--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -29,7 +29,7 @@ Default `options`:
     type: undefined // sets the stream type (NEW_IMAGE | OLD_IMAGE | NEW_AND_OLD_IMAGES | KEYS_ONLY) (https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_StreamSpecification.html#DDB-Type-StreamSpecification-StreamViewType)
   },
   serverSideEncryption: false, // Set SSESpecification.Enabled (server-side encryption) to true or false (default: false)
-  defaultReturnValues: 'ALL_NEW', // sets ReturnValues for the UpdateItem operation (NONE | ALL_OLD | UPDATED_OLD | ALL_NEW | UPDATED_NEW) (https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateItem.html)
+  defaultReturnValues: 'ALL_NEW' // sets ReturnValues for the UpdateItem operation (NONE | ALL_OLD | UPDATED_OLD | ALL_NEW | UPDATED_NEW) (https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateItem.html)
 }
 ```
 

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -29,7 +29,7 @@ Default `options`:
     type: undefined // sets the stream type (NEW_IMAGE | OLD_IMAGE | NEW_AND_OLD_IMAGES | KEYS_ONLY) (https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_StreamSpecification.html#DDB-Type-StreamSpecification-StreamViewType)
   },
   serverSideEncryption: false, // Set SSESpecification.Enabled (server-side encryption) to true or false (default: false)
-  defaultReturnValues: 'ALL_NEW' // sets ReturnValues for the UpdateItem operation (NONE | ALL_OLD | UPDATED_OLD | ALL_NEW | UPDATED_NEW) (https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateItem.html)
+  defaultReturnValues: 'ALL_NEW', // sets ReturnValues for the UpdateItem operation (NONE | ALL_OLD | UPDATED_OLD | ALL_NEW | UPDATED_NEW) (https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateItem.html)
 }
 ```
 
@@ -60,6 +60,10 @@ const model = dynamoose.model('Cat', {...}, {
   serverSideEncryption: true
 });
 ```
+
+tableName: string
+
+Overrides the table name which is generated automatically by Dynamoose. This option can be used to provide custom table names for cases where the name of a model does not directly map to the table that it lives in. It can also be used to allow multiple models to reside in a single table.
 
 ### dynamoose.local(url)
 

--- a/dynamoose.d.ts
+++ b/dynamoose.d.ts
@@ -44,6 +44,7 @@ declare module "dynamoose" {
       type: 'NEW_IMAGE'|'OLD_IMAGE'|'NEW_AND_OLD_IMAGES'|'KEYS_ONLY', // https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_StreamSpecification.html#DDB-Type-StreamSpecification-StreamViewType
     },
     serverSideEncryption?: boolean, // Set SSESpecification.Enabled (server-side encryption) to true or false (default: true)
+    tableName?: string, // Override the table name for the model
   }
 
   /**

--- a/lib/Dynamoose.ts
+++ b/lib/Dynamoose.ts
@@ -48,6 +48,7 @@ export interface IDynamooseOptions extends ISchemaOptions {
   suffix?: string;
   serverSideEncryption?: boolean;
   defaultReturnValues?: string;
+  tableName?: string;
 }
 export interface ITransactionOptions {
   type?: string;
@@ -59,11 +60,12 @@ export function createLocalDb (endpointURL: string) {
   dynamoConfig['endpoint'] = new AWS.Endpoint(endpointURL);
   return new AWS.DynamoDB(dynamoConfig);
 }
+
 export function getModelSchemaFromIndex (item: any, dynamoose: Dynamoose) {
   const requestItem = item;
   const [requestItemProperty] = Object.keys(item);
   const tableName = requestItem[requestItemProperty].TableName;
-  const TheModel = dynamoose.models[tableName];
+  const TheModel = requestItem._dynamooseModel;
   if (!TheModel) {
     const errorMessage = `${tableName} is not a registered model. You can only use registered Dynamoose models when using a RAW transaction object.`;
     throw new errors.TransactionError(errorMessage);
@@ -143,6 +145,7 @@ class Dynamoose {
 
     const model = Model.compile(name, schema, options, this);
     this.models[name] = model;
+
     return model;
   }
   /**
@@ -257,7 +260,12 @@ class Dynamoose {
     const tmpItems = await Promise.all(items);
     items = tmpItems;
     const transactionReq = {
-      'TransactItems': items
+      'TransactItems': items.map(i => {
+        // Omit the dynamoose model reference.
+        const itemCopy = Object.assign({}, i);
+        delete itemCopy._dynamooseModel;
+        return itemCopy;
+      })
     };
     let transactionMethodName;
     if (builtOptions.type) {

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -108,7 +108,8 @@ function sendErrorToCallback (error, options, next) {
 Model.compile = function compile (name, schema, options, base) {
   debug('compiling NewModel %s', name);
 
-  const table = new Table(name, schema, options, base);
+  const {tableName} = options || {};
+  const table = new Table(tableName || name, schema, options, base);
 
   function NewModel (obj) {
     Model.call(this, obj);
@@ -343,7 +344,7 @@ Model.compile = function compile (name, schema, options, base) {
         delete requestObj.ReturnValues;
       }
 
-      return {[val]: requestObj};
+      return {[val]: requestObj, '_dynamooseModel': NewModel};
     };
   }
   NewModel.transaction = [
@@ -409,7 +410,7 @@ Model.conditionCheck = async function (NewModel, key, options, next) {
     }
 
     const conditionReq = {
-      'TableName': NewModel.$__.name,
+      'TableName': NewModel.$__.table.name,
       'Key': {}
     };
     try {
@@ -491,7 +492,7 @@ Model.prototype.put = async function (options, next) {
 
     const {schema} = this.$__;
     item = {
-      'TableName': this.$__.name,
+      'TableName': this.$__.table.name,
       'Item': await schema.toDynamo(this, toDynamoOptions)
     };
 
@@ -587,7 +588,7 @@ Model.get = async function (NewModel, key, options, next) {
 
 
   let getReq = {
-    'TableName': NewModel.$__.name,
+    'TableName': NewModel.$__.table.name,
     'Key': {}
   };
 
@@ -811,7 +812,7 @@ Model.update = async function (NewModel, key, update, options, next) {
   }
 
   const updateReq = {
-    'TableName': NewModel.$__.name,
+    'TableName': NewModel.$__.table.name,
     'Key': {},
     'ExpressionAttributeNames': {},
     'ExpressionAttributeValues': {},
@@ -1347,7 +1348,7 @@ Model.batchGet = async function (NewModel, keys, options, next) {
   };
 
   const getReq = {};
-  batchReq.RequestItems[NewModel.$__.name] = getReq;
+  batchReq.RequestItems[NewModel.$__.table.name] = getReq;
 
   getReq.Keys = await Promise.all(keys.map(async (key) => {
     const ret = {};

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -1394,10 +1394,23 @@ Model.batchGet = async function (NewModel, keys, options, next) {
         return model;
       }
 
-      const models = data.Responses[newModel$.name] ? (await Promise.all(data.Responses[newModel$.name].map(toModel))).filter((item) => !(schema.expires && schema.expires.returnExpiredItems === false && item[schema.expires.attribute] && item[schema.expires.attribute] < new Date())) : [];
-      if (data.UnprocessedKeys[newModel$.name]) {
+      const modelTableName = newModel$.table.name;
+      const models = data.Responses[modelTableName]
+        ? (await Promise.all(
+          data.Responses[modelTableName].map(toModel)
+        )).filter(
+          (item) => !(
+            schema.expires &&
+                schema.expires.returnExpiredItems === false &&
+                item[schema.expires.attribute] &&
+                item[schema.expires.attribute] < new Date()
+          )
+        )
+        : [];
+
+      if (data.UnprocessedKeys[modelTableName]) {
         // convert unprocessed keys back to dynamoose format
-        models.unprocessed = await Promise.all(data.UnprocessedKeys[newModel$.name].Keys.map(async (key) => {
+        models.unprocessed = await Promise.all(data.UnprocessedKeys[modelTableName].Keys.map(async (key) => {
           const ret = {};
           ret[hashKeyName] = await schema.hashKey.parseDynamo(key[hashKeyName]);
 
@@ -1421,7 +1434,7 @@ Model.batchGet = async function (NewModel, keys, options, next) {
   return deferred.promise.nodeify(next);
 };
 
-async function toBatchChunks (modelName, list, chunkSize, requestMaker) {
+async function toBatchChunks (tableName, list, chunkSize, requestMaker) {
   const listClone = list.slice(0);
   let chunk = [];
   const batchChunks = [];
@@ -1432,7 +1445,7 @@ async function toBatchChunks (modelName, list, chunkSize, requestMaker) {
       'RequestItems': {}
     };
 
-    batchReq.RequestItems[modelName] = requests;
+    batchReq.RequestItems[tableName] = requests;
     batchChunks.push(batchReq);
   }
 
@@ -1506,7 +1519,7 @@ Model.batchPut = async function (NewModel, items, options, next) {
     options = {};
   }
 
-  const {schema} = NewModel.$__;
+  const {schema, table} = NewModel.$__;
   const newModel$ = NewModel.$__;
 
   const toDynamoOptions = {
@@ -1514,7 +1527,7 @@ Model.batchPut = async function (NewModel, items, options, next) {
     'updateExpires': options.updateExpires || false
   };
 
-  const batchRequests = await toBatchChunks(newModel$.name, items, MAX_BATCH_WRITE_SIZE, async (item) => ({
+  const batchRequests = await toBatchChunks(table.name, items, MAX_BATCH_WRITE_SIZE, async (item) => ({
     'PutRequest': {
       'Item': await schema.toDynamo(item, toDynamoOptions)
     }
@@ -1551,11 +1564,11 @@ Model.batchDelete = async function (NewModel, keys, options, next) {
     options = {};
   }
 
-  const {schema} = NewModel.$__;
+  const {schema, table} = NewModel.$__;
   const newModel$ = NewModel.$__;
   const hashKeyName = schema.hashKey.name;
 
-  const batchRequests = await toBatchChunks(newModel$.name, keys, MAX_BATCH_WRITE_SIZE, async (key) => {
+  const batchRequests = await toBatchChunks(table.name, keys, MAX_BATCH_WRITE_SIZE, async (key) => {
     const key_element = {};
     key_element[hashKeyName] = await schema.hashKey.toDynamo(key[hashKeyName], undefined, key);
 

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -1189,7 +1189,7 @@ Model.prototype.delete = async function (options, next) {
 
 
   const getDelete = {
-    'TableName': this.$__.name,
+    'TableName': this.$__.table.name,
     'Key': {}
   };
 

--- a/lib/Query.js
+++ b/lib/Query.js
@@ -80,7 +80,7 @@ Query.prototype.exec = async function (next) {
   debug('Query with schema', schema);
 
   let queryReq = {
-    'TableName': Model.$__.name,
+    'TableName': Model.$__.table.name,
     'KeyConditions': {}
   };
 

--- a/lib/Scan.js
+++ b/lib/Scan.js
@@ -110,7 +110,7 @@ Scan.prototype.exec = async function (next) {
       scanReq = {};
     }
     if (!scanReq.TableName) {
-      scanReq.TableName = Model.$__.name;
+      scanReq.TableName = Model.$__.table.name;
     }
 
     // use the document client in aws-sdk
@@ -119,7 +119,7 @@ Scan.prototype.exec = async function (next) {
   }
   // default
   scanReq = {
-    'TableName': Model.$__.name
+    'TableName': Model.$__.table.name
   };
 
   if (Object.keys(this.filters).length > 0) {

--- a/lib/Table.js
+++ b/lib/Table.js
@@ -520,7 +520,11 @@ Table.prototype.create = function (next) {
 
   ddb.createTable(createTableReq, (err, data) => {
     if (err) {
-      debug('error creating table', err);
+      debug('error creating table', err, createTableReq);
+      if (err.code === 'ResourceInUseException') {
+        debug('table was already created');
+        return deferred.resolve(this.describe());
+      }
       return deferred.reject(err);
     }
     debug('table created', data);

--- a/test/Model.js
+++ b/test/Model.js
@@ -3620,7 +3620,7 @@ describe('Model', function () {
       should.not.exist(result);
     });
 
-    it.only('should work with shared table model', async () => {
+    it('should work with shared table model', async () => {
       let result;
 
       try {

--- a/test/fixtures/Cats.js
+++ b/test/fixtures/Cats.js
@@ -394,6 +394,23 @@ module.exports = function (dynamoose) {
     'defaultReturnValues': 'NONE'
   });
 
+  const SharedTableCat1 = new dynamoose.Schema({
+    'id': Number,
+    'name': String,
+    'breed': String
+  });
+  const SharedTableCat2 = new dynamoose.Schema({
+    'id': Number,
+    'name': String,
+    'color': String
+  });
+  const CatWithBreed = dynamoose.model('CatWithBreed', SharedTableCat1, {
+    'tableName': 'shared-cat'
+  });
+  const CatWithColor = dynamoose.model('CatWithColor', SharedTableCat2, {
+    'tableName': 'shared-cat'
+  });
+
   return {
     Cat,
     Cat1,
@@ -418,6 +435,8 @@ module.exports = function (dynamoose) {
     CatWithGeneratedID,
     CatWithMethods,
     CatModel,
-    ReturnValuesNoneCat
+    ReturnValuesNoneCat,
+    CatWithBreed,
+    CatWithColor
   };
 };


### PR DESCRIPTION
<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->

### Summary:

I mostly wanted to get this PR up early to see if there's any feedback from the maintainers about the direction that I went. I tried to use a light touch to empower developers to use Dynamoose to fulfill their use-case, but without making any major changes to the way the library structures schemas or models.

In my use-case, we have a single table which backs two similar models with a simple range-key based discriminator which we use to differentiate between the two models. Our use case would also benefit from being able to provide a unique name for a model, but using a distinct table name. This change allows Dynamoose to create multiple models which back on to a single table. It does not (yet?) make use of any kind of discriminator to decide if a model being loaded is a member of one schema or another.

Currently all of the operations in Dynamoose rely on the model "name" to decide which table to operate against. This PR separates the concept of the table name and the model name, such that we can have two schemas and models which use the same backing table for operations. This change also required a bit of work to be done on the Transaction system, as it relied on being able to do a lookup in a map which defined a table to model relationship. Since we have the possibility of multiple models per table, this map was no longer valid.

<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:
#### Schema
```javascript
  const SharedTableCat1 = new dynamoose.Schema({
    'id': Number,
    'name': String,
    'breed': String
  });
  const SharedTableCat2 = new dynamoose.Schema({
    'id': Number,
    'name': String,
    'color': String
  });
```

#### Model
```javascript
  const CatWithBreed = dynamoose.model('CatWithBreed', SharedTableCat1, {
    'tableName': 'shared-cat'
  });
  const CatWithColor = dynamoose.model('CatWithColor', SharedTableCat2, {
    'tableName': 'shared-cat'
  });
```

#### General
```
// Explicit inline filtering is still required to ensure we get the correct records back.
// We may be able to define some kind of implicit filter that gets applied to all 
// scans/queries for a model to ensure that we only get the records we want back.
const brownCat = await CatWithColor.query('id').eq(1).filter('color').eq('brown');
const tabbyCat = await CatWithBreed.query('id').eq(2).filter('breed').eq('tabby');
```


<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->

https://github.com/dynamoosejs/dynamoose/issues/295


<!-- Please remove the `Other information` section below if it doesn't apply to this PR -->
### Other information:


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
