### PR TITLE
Fix markdown list in doc

### DIFF
--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -47,6 +47,7 @@ odie.save({
 ```
 
 Options:
+
   - overwrite: should overwrite the existing item in DynamoDB (default: true)
   - updateExpires: should update the expires timestamp if exists (default: false)
   - updateTimestamps: should update the updatedAt timestamp if exists (default: true)


### PR DESCRIPTION
### Summary:

There must a new line before a list in markdown. The page looks good on GitHub but in the documentation website: https://dynamoosejs.com/api/model/#modelputoptions-callback-modelsaveoptions-callback

![image](https://user-images.githubusercontent.com/62333/62051093-ea34e000-b212-11e9-94f7-45ed14035051.png)

### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [ ] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
