### PR TITLE
feat: use FilterExpression strings in Query

### DIFF
--- a/lib/FilterExpression.js
+++ b/lib/FilterExpression.js
@@ -1,0 +1,148 @@
+'use strict';
+const AWS = require('aws-sdk');
+const errors = require('./errors');
+
+function FilterExpressionNode (operation, attribute, value) {
+  this.operation = operation;
+  this.attribute = attribute;
+  this.value = value;
+
+  this.prev = null;
+  this.next = null;
+}
+
+function FilterExpression () {
+  this.head = null;
+  this.tail = null;
+
+  this.nameIndex = 1;
+  this.valueIndex = 1;
+
+  this.attributeNames = {};
+  this.attributeValues = {};
+
+  this.currentFilterAttribute = null;
+}
+
+FilterExpression.prototype.addNode = function (node) {
+  if (!this.head) {
+    this.head = node;
+    this.tail = node;
+  } else if (this.tail) {
+    this.tail.next = node;
+    node.prev = this.tail;
+    this.tail = node;
+  }
+};
+
+FilterExpression.prototype.addName = function (name) {
+  const attributeName = `#attr${this.nameIndex}`;
+  this.nameIndex = this.nameIndex + 1;
+
+  this.attributeNames[attributeName] = name;
+
+  return attributeName;
+};
+
+FilterExpression.prototype.addValue = function (value) {
+  const attributeName = `:val${this.valueIndex}`;
+  this.valueIndex = this.valueIndex + 1;
+
+  const attributeValue = AWS.DynamoDB.Converter.input(value);
+  this.attributeValues[attributeName] = attributeValue;
+
+  return attributeName;
+};
+
+FilterExpression.prototype.filter = function (attribute) {
+  this.currentFilterAttribute = this.addName(attribute);
+  return this;
+};
+
+FilterExpression.prototype.and = function () {
+  this.addNode(new FilterExpressionNode('AND'));
+  return this;
+};
+
+FilterExpression.prototype.or = function () {
+  this.addNode(new FilterExpressionNode('OR'));
+  return this;
+};
+
+FilterExpression.prototype.not = function () {
+  this.addNode(new FilterExpressionNode('NOT'));
+  return this;
+};
+
+FilterExpression.prototype.comparison = function (operation, value) {
+  if (!this.currentFilterAttribute) {
+    throw new errors.FilterExpressionError(`comparison "${operation}" must be preceded by a filter(attribute) call.`);
+  }
+
+  const valueName = this.addValue(value);
+  this.addNode(new FilterExpressionNode(operation, this.currentFilterAttribute, valueName));
+  return this;
+};
+
+FilterExpression.prototype.func = function (func, value) {
+  if (!this.currentFilterAttribute) {
+    throw new errors.FilterExpressionError(`function "${func}" must be preceded by a filter(attribute) call.`);
+  }
+
+  const valueName = value ? this.addValue(value) : null;
+  this.addNode(new FilterExpressionNode(func, this.currentFilterAttribute, valueName));
+  return this;
+};
+
+FilterExpression.prototype.in = function (values) {
+  if (!this.currentFilterAttribute) {
+    throw new errors.FilterExpressionError('operation "IN" must be preceded by a filter(attribute) call.');
+  }
+
+  const valueNames = values.map((value) => this.addValue(value));
+  this.addNode(new FilterExpressionNode('IN', this.currentFilterAttribute, valueNames));
+  return this;
+};
+
+FilterExpression.prototype.between = function (op1, op2) {
+  if (!this.currentFilterAttribute) {
+    throw new errors.FilterExpressionError('operation "BETWEEN" must be preceded by a filter(attribute) call.');
+  }
+
+  const op1Name = this.addValue(op1);
+  const op2Name = this.addValue(op2);
+  this.addNode(new FilterExpressionNode('BETWEEN', this.currentFilterAttribute, [op1Name, op2Name]));
+  return this;
+};
+
+const isFunction = (node) => ['attribute_exists', 'attribute_not_exists', 'attribute_type', 'begins_with', 'contains'].includes(node.operation.toLowerCase());
+
+FilterExpression.prototype.toString = function () {
+  let node = this.head;
+  let filterExpressionString = '';
+  if (!node) {
+    return null;
+  }
+
+  while (node) {
+    if (isFunction(node)) {
+      const value = node.value ? `, ${node.value}` : '';
+      filterExpressionString += `${node.operation}(${node.attribute}${value})`;
+    } else if (node.operation === 'BETWEEN') {
+      filterExpressionString += `${node.attribute} BETWEEN ${node.value[0]} AND ${node.value[1]}`;
+    } else if (node.operation === 'IN') {
+      const values = node.value.join(', ');
+      filterExpressionString += `${node.attribute} IN (${values})`;
+    } else {
+      const genericFilterPart = [node.attribute, node.operation, node.value].filter((part) => part).join(' ');
+      filterExpressionString += genericFilterPart;
+    }
+
+    filterExpressionString += ' ';
+    node = node.next;
+  }
+
+  return filterExpressionString.trim();
+};
+
+module.exports = FilterExpression;

--- a/lib/Query.js
+++ b/lib/Query.js
@@ -2,6 +2,7 @@
 const Q = require('q');
 const errors = require('./errors');
 const debug = require('debug')('dynamoose:query');
+const FilterExpression = require('./FilterExpression');
 
 function Query (Model, query, options) {
   this.Model = Model;
@@ -21,7 +22,7 @@ function Query (Model, query, options) {
   // }
   this.query = {'hashKey': {}};
 
-  this.filters = {};
+  this.filterExpression = new FilterExpression();
   this.buildState = false;
   this.validationError = null;
 
@@ -151,33 +152,11 @@ Query.prototype.exec = async function (next) {
   }
 
 
-  if (this.filters && Object.keys(this.filters).length > 0) {
-    queryReq.QueryFilter = {};
-    for (const name in this.filters) {
-      debug('Filter on: %s', name);
-      const filter = this.filters[name];
-      const filterAttr = schema.attributes[name];
-      queryReq.QueryFilter[name] = {
-        'AttributeValueList': [],
-        'ComparisonOperator': filter.comparison.toUpperCase()
-      };
-
-      const isContains = filter.comparison === 'CONTAINS' || filter.comparison === 'NOT_CONTAINS';
-      const isListContains = isContains && filterAttr.type.name === 'list';
-
-      if (filter.values) {
-        for (i = 0; i < filter.values.length; i += 1) {
-          val = filter.values[i];
-          queryReq.QueryFilter[name].AttributeValueList.push(
-            isListContains ? await filterAttr.attributes[0].toDynamo(val, true, Model, {'updateTimestamps': false}) : await filterAttr.toDynamo(val, true, Model, {'updateTimestamps': false})
-          );
-        }
-      }
-    }
-  }
-
-  if (options.or) {
-    queryReq.ConditionalOperator = 'OR'; // defualts to AND
+  const renderedFilterExpression = this.filterExpression.toString();
+  if (renderedFilterExpression !== null) {
+    queryReq.FilterExpression = renderedFilterExpression;
+    queryReq.ExpressionAttributeNames = this.filterExpression.attributeNames;
+    queryReq.ExpressionAttributeValues = this.filterExpression.attributeValues;
   }
 
   if (options.attributes) {
@@ -341,40 +320,65 @@ Query.prototype.filter = function (filter) {
     this.validationError = new errors.QueryError('Invalid Query state: filter() must follow comparison');
     return this;
   }
+
+  // Filters were originally written to use a global "OR"/"AND" flag which determined the logical
+  // operation with which filters joined. You could not mix OR/AND. This is to maintain that support.
+  if (this.filterExpression.toString() !== null) {
+    if (this.options.or) {
+      this.filterExpression.or();
+    } else {
+      this.filterExpression.and();
+    }
+  }
   if (typeof filter === 'string') {
     this.buildState = 'filter';
-    this.currentFilter = filter;
-    if (this.filters[filter]) {
-      this.validationError = new errors.QueryError('Invalid Query state: %s filter can only be used once', filter);
-      return this;
-    }
-    this.filters[filter] = {'name': filter};
+    this.filterExpression.filter(filter);
   }
 
   return this;
 };
 
 const VALID_RANGE_KEYS = ['EQ', 'LE', 'LT', 'GE', 'GT', 'BEGINS_WITH', 'BETWEEN'];
+const COMPARATOR_MAP = {
+  'EQ': '=',
+  'LE': '<=',
+  'LT': '<',
+  'GE': '>=',
+  'GT': '>'
+};
+
+const COMPARATOR_NEGATION_MAP = {
+  'LE': 'GT',
+  'LT': 'GE',
+  'GE': 'LT',
+  'GT': 'LE'
+};
+
 Query.prototype.compVal = function (vals, comp) {
   if (this.validationError) {
     return this;
   }
+
+  const toArray = function (val) { return Array.isArray(val) ? val : [val]; };
   if (this.buildState === 'hashKey') {
     if (comp !== 'EQ') {
       this.validationError = new errors.QueryError('Invalid Query state: eq must follow query()');
       return this;
     }
-    [this.query.hashKey.value] = vals;
+    [this.query.hashKey.value] = toArray(vals);
   } else if (this.buildState === 'rangeKey') {
     if (VALID_RANGE_KEYS.indexOf(comp) < 0) {
       this.validationError = new errors.QueryError('Invalid Query state: %s must follow filter()', comp);
       return this;
     }
-    this.query.rangeKey.values = vals;
+    if (this.notState) {
+      comp = COMPARATOR_NEGATION_MAP[comp];
+    }
+    this.query.rangeKey.values = toArray(vals);
     this.query.rangeKey.comparison = comp;
   } else if (this.buildState === 'filter') {
-    this.filters[this.currentFilter].values = vals;
-    this.filters[this.currentFilter].comparison = comp;
+    const comparator = COMPARATOR_MAP[comp];
+    this.filterExpression.comparison(comparator, vals);
   } else {
     this.validationError = new errors.QueryError('Invalid Query state: %s must follow query(), where() or filter()', comp);
     return this;
@@ -399,100 +403,82 @@ Query.prototype.or = function () {
 };
 
 Query.prototype.not = function () {
-  this.notState = true;
+  if (this.buildState === 'rangeKey') {
+    this.notState = true;
+  } else {
+    this.filterExpression.not();
+  }
   return this;
 };
 
 Query.prototype.null = function () {
-  if (this.notState) {
-    return this.compVal(null, 'NOT_NULL');
-  }
-  return this.compVal(null, 'NULL');
-
+  return this.compVal(null, 'EQ');
 };
 
 
 Query.prototype.eq = function (val) {
-  if (this.notState) {
-    return this.compVal([val], 'NE');
-  }
-  return this.compVal([val], 'EQ');
-
+  return this.compVal(val, 'EQ');
 };
 
 
 Query.prototype.lt = function (val) {
-  if (this.notState) {
-    return this.compVal([val], 'GE');
-  }
-  return this.compVal([val], 'LT');
-
+  return this.compVal(val, 'LT');
 };
 
 Query.prototype.le = function (val) {
-  if (this.notState) {
-    return this.compVal([val], 'GT');
-  }
-  return this.compVal([val], 'LE');
-
+  return this.compVal(val, 'LE');
 };
 
 Query.prototype.ge = function (val) {
-  if (this.notState) {
-    return this.compVal([val], 'LT');
-  }
-  return this.compVal([val], 'GE');
-
+  return this.compVal(val, 'GE');
 };
 
 Query.prototype.gt = function (val) {
-  if (this.notState) {
-    return this.compVal([val], 'LE');
-  }
-  return this.compVal([val], 'GT');
-
+  return this.compVal(val, 'GT');
 };
 
 Query.prototype.contains = function (val) {
-  if (this.notState) {
-    return this.compVal([val], 'NOT_CONTAINS');
-  }
-  return this.compVal([val], 'CONTAINS');
-
+  this.filterExpression.func('contains', val);
+  this.buildState = false;
+  return this;
 };
 
 Query.prototype.beginsWith = function (val) {
   if (this.validationError) {
     return this;
   }
-  if (this.notState) {
-    this.validationError = new errors.QueryError('Invalid Query state: beginsWith() cannot follow not()');
-    return this;
+
+  if (this.buildState === 'rangeKey') {
+    return this.compVal(val, 'BEGINS_WITH');
   }
-  return this.compVal([val], 'BEGINS_WITH');
+
+  this.filterExpression.func('begins_with', val);
+  this.buildState = false;
+  return this;
 };
 
 Query.prototype.in = function (vals) {
   if (this.validationError) {
     return this;
   }
-  if (this.notState) {
-    this.validationError = new errors.QueryError('Invalid Query state: in() cannot follow not()');
-    return this;
-  }
 
-  return this.compVal(vals, 'IN');
+  this.filterExpression.in(vals);
+  this.buildState = false;
+  return this;
 };
 
 Query.prototype.between = function (a, b) {
   if (this.validationError) {
     return this;
   }
-  if (this.notState) {
-    this.validationError = new errors.QueryError('Invalid Query state: between() cannot follow not()');
-    return this;
+
+  if (this.buildState === 'rangeKey') {
+    return this.compVal([a, b], 'BETWEEN');
   }
-  return this.compVal([a, b], 'BETWEEN');
+
+  this.filterExpression.between(a, b);
+  this.buildState = false;
+  return this;
 };
 
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -20,5 +20,6 @@ module.exports = {
   'ScanError': new ErrorType('Error with scan', 'ScanError'),
   'TransactionError': new ErrorType('Error with transaction', 'TransactionError'),
   'ValidationError': new ErrorType('Validation error', 'ValidationError'),
-  'ParseError': new ErrorType('Parse error', 'ParseError')
+  'ParseError': new ErrorType('Parse error', 'ParseError'),
+  'FilterExpressionError': new ErrorType('Filter Expression error', 'FilterExpressionError')
 };

--- a/test/FilterExpression.js
+++ b/test/FilterExpression.js
@@ -2,7 +2,7 @@
 const should = require('should');
 const FilterExpression = require('../lib/FilterExpression');
 
-describe.only('FilterExpression', () => {
+describe('FilterExpression', () => {
   let expression;
 
   beforeEach(() => {

--- a/test/FilterExpression.js
+++ b/test/FilterExpression.js
@@ -2,7 +2,7 @@
 const should = require('should');
 const FilterExpression = require('../lib/FilterExpression');
 
-describe('FilterExpression', () => {
+describe.only('FilterExpression', () => {
   let expression;
 
   beforeEach(() => {
@@ -69,5 +69,21 @@ describe('FilterExpression', () => {
   it('can construct BETWEEN filter', () => {
     expression.filter('time').between('2019-01-01', '2019-12-31');
     expression.toString().should.equal('#attr1 BETWEEN :val1 AND :val2');
+  });
+
+  it('cannot perform a comparison without an attribute', () => {
+    should.throws(() => expression.comparison('=', 42), 'comparison "=" must be preceded by a filter(attribute) call.');
+  });
+
+  it('cannot perform a function without an attribute', () => {
+    should.throws(() => expression.func('begins_with', 42), 'function "=" must be preceded by a filter(attribute) call.');
+  });
+
+  it('cannot construct IN filter without an attribute', () => {
+    should.throws(() => expression.in([1, 2, 3]), 'operation "IN" must be preceded by a filter(attribute) call.');
+  });
+
+  it('cannot construct BETWEEN filter without an attribute', () => {
+    should.throws(() => expression.between(10, 42), 'operation "BETWEEN" must be preceded by a filter(attribute) call.');
   });
 });

--- a/test/FilterExpression.js
+++ b/test/FilterExpression.js
@@ -1,0 +1,73 @@
+'use strict';
+const should = require('should');
+const FilterExpression = require('../lib/FilterExpression');
+
+describe('FilterExpression', () => {
+  let expression;
+
+  beforeEach(() => {
+    expression = new FilterExpression();
+  });
+
+  it('returns null if no operations', () => should(expression.toString()).be.null());
+
+  it('can filter an attribute', () => {
+    expression.filter('foo').comparison('=', '42');
+    expression.toString().should.equal('#attr1 = :val1');
+  });
+
+  it('can combine filters with and', () => {
+    expression.filter('foo').comparison('>', 24).and().comparison('<', 35);
+    expression.toString().should.equal('#attr1 > :val1 AND #attr1 < :val2');
+  });
+
+  it('can combine filters with or', () => {
+    expression.filter('fizz').comparison('=', 'buzz').or().comparison('=', 'fuzz');
+    expression.toString().should.equal('#attr1 = :val1 OR #attr1 = :val2');
+  });
+
+  it('can negate filters with not', () => {
+    expression.not().filter('fizz').comparison('=', 'buzz');
+    expression.toString().should.equal('NOT #attr1 = :val1');
+  });
+
+  it('can construct attribute_exists filter', () => {
+    expression.filter('foo').func('attribute_exists');
+    expression.toString().should.equal('attribute_exists(#attr1)');
+  });
+
+  it('can construct attribute_not_exists filter', () => {
+    expression.filter('foo').func('attribute_not_exists');
+    expression.toString().should.equal('attribute_not_exists(#attr1)');
+  });
+
+  it('can construct attribute_type filter', () => {
+    expression.filter('fizz').func('attribute_type', 'SS');
+    expression.toString().should.equal('attribute_type(#attr1, :val1)');
+  });
+
+  it('can construct begins_with filter', () => {
+    expression.filter('fizz').func('begins_with', 'foo');
+    expression.toString().should.equal('begins_with(#attr1, :val1)');
+  });
+
+  it('can construct contains filter', () => {
+    expression.filter('fizz').func('contains', 'foo');
+    expression.toString().should.equal('contains(#attr1, :val1)');
+  });
+
+  it('can combine functions', () => {
+    expression.filter('foo').comparison('=', 'bar').and().filter('fizz').func('contains', 'buzz');
+    expression.toString().should.equal('#attr1 = :val1 AND contains(#attr2, :val2)');
+  });
+
+  it('can construct IN filter', () => {
+    expression.filter('foo').in(['fizz', 'buzz', 'bar']);
+    expression.toString().should.equal('#attr1 IN (:val1, :val2, :val3)');
+  });
+
+  it('can construct BETWEEN filter', () => {
+    expression.filter('time').between('2019-01-01', '2019-12-31');
+    expression.toString().should.equal('#attr1 BETWEEN :val1 AND :val2');
+  });
+});

--- a/test/Query.js
+++ b/test/Query.js
@@ -533,21 +533,6 @@ describe('Query', function () {
 
   });
 
-  it('beginsWith() cannot follow not()', async () => {
-    const Dog = dynamoose.model('Dog');
-
-    let error;
-    try {
-      await Dog.query('breed').eq('Jack Russell Terrier').filter('color').not().contains('Brown').or().filter('name').not().beginsWith('Q').exec();
-    } catch (e) {
-      error = e;
-    }
-
-    should.exist(error);
-    should.exist(error.message);
-    error.message.should.eql('Invalid Query state: beginsWith() cannot follow not()');
-  });
-
   it('Basic Query on SGI with filter between', (done) => {
     const Dog = dynamoose.model('Dog');
 
@@ -561,21 +546,6 @@ describe('Query', function () {
       });
   });
 
-  it('between() cannot follow not()', async () => {
-    const Dog = dynamoose.model('Dog');
-
-    let error;
-    try {
-      await Dog.query('breed').eq('Jack Russell Terrier').filter('age').not().between(5, 7).exec();
-    } catch (e) {
-      error = e;
-    }
-
-    should.exist(error);
-    should.exist(error.message);
-    error.message.should.eql('Invalid Query state: between() cannot follow not()');
-  });
-
   it('Basic Query on SGI with filter in', (done) => {
     const Dog = dynamoose.model('Dog');
 
@@ -587,21 +557,6 @@ describe('Query', function () {
         dogs[0].ownerId.should.eql(2);
         done();
       });
-  });
-
-  it('in() cannot follow not()', async () => {
-    const Dog = dynamoose.model('Dog');
-
-    let error;
-    try {
-      await Dog.query('breed').eq('Jack Russell Terrier').filter('color').not().in(['White and Brown', 'White']).exec();
-    } catch (e) {
-      error = e;
-    }
-
-    should.exist(error);
-    should.exist(error.message);
-    error.message.should.eql('Invalid Query state: in() cannot follow not()');
   });
 
   it('Query.count', (done) => {


### PR DESCRIPTION
<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->

### Summary:

Currently Queries (and Scans) are using the legacy QueryFilter API to perform post-query filtering. 
This PR changes the existing filter implementation for Query to use the FilterExpression attribute instead of QueryFilter. While I tried to make this change as minimal as possible, the following operations are now possible when filtering attributes:

1. Using NOT before BETWEEN
2. Using NOT before BEGINS_WITH
3. Using NOT before IN

Please note that this PR does **not** address the following:
1. Using FilterExpression in `scan` operations. I attempted this, but some very strange patterns in the Scan code made me abandon ship before getting anywhere. It seems like there's some skeletons buried in there.

2. Using `KeyConditionExpression` instead of `KeyConditions`. I'd imagine that the same `FilterExpression` logic could be used to construct this, however. Worth looking in to on a future PR.

<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:

There are no changes to the exposed Dynamoose APIs.

<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->
#---


<!-- Please remove the `Other information` section below if it doesn't apply to this PR -->
### Other information:


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
