### PR TITLE
fix: fixing model.transaction.conditioncheck

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -413,14 +413,14 @@ Model.conditionCheck = async function (NewModel, key, options, next) {
       'Key': {}
     };
     try {
-      conditionReq.Key[hashKeyName] = schema.hashKey.toDynamo(key[hashKeyName], undefined, key);
+      conditionReq.Key[hashKeyName] = await schema.hashKey.toDynamo(key[hashKeyName], undefined, key);
     } catch (e) {
       deferred.reject(e);
     }
 
     if (schema.rangeKey) {
       const rangeKeyName = schema.rangeKey.name;
-      conditionReq.Key[rangeKeyName] = schema.rangeKey.toDynamo(key[rangeKeyName], undefined, key);
+      conditionReq.Key[rangeKeyName] = await schema.rangeKey.toDynamo(key[rangeKeyName], undefined, key);
     }
     await processCondition(conditionReq, options, NewModel);
 


### PR DESCRIPTION
fix #539

<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->


### Summary:
When doing transactions, the `Key` param had the table key values as promises and dynamo would throw the error `Validation Error: Supplied AttributeValue is empty, must contain exactly one of the supported datatypes`. This PR simply resolved the promises on the key values.



<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->


<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->
#539

### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
