### PR TITLE
fix: fixing cannot read property 'type' of null

### DIFF
--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -191,7 +191,7 @@ Attribute.prototype.setTypeFromRawValue = function (value) {
   // no type defined - assume this is not a type definition and we must grab type directly from value
   let type;
   let typeVal = value;
-  if (value.type) {
+  if (value && value.type) {
     typeVal = value.type;
   }
 
@@ -205,7 +205,7 @@ Attribute.prototype.setTypeFromRawValue = function (value) {
     if (type === 'Object') {
       type = 'Map';
     }
-  } else if (typeof typeVal === 'object' || typeVal === 'map') {
+  } else if ((typeVal && typeof typeVal === 'object') || typeVal === 'map') {
     type = 'Map';
   } else {
     type = typeof typeVal;

--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -6,7 +6,7 @@ function Attribute (schema, name, value) {
   this.options = {};
 
   debug('Creating attribute %s %o', name, value);
-  if (value.type) {
+  if (value && value.type) {
     this.options = value;
   }
 

--- a/lib/Attribute.js
+++ b/lib/Attribute.js
@@ -728,7 +728,7 @@ module.exports.create = function (schema, name, obj) {
 
   const value = obj;
   let options = {};
-  if (typeof obj === 'object' && obj.type) {
+  if (obj && typeof obj === 'object' && obj.type) {
     options = obj;
   }
 


### PR DESCRIPTION
Fixes a bug where a nested object property is null, this would cause this line to error because typeof null returns 'object' but obj.type would cause an exception.

<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->


### Summary:
Cannot read property 'type' of null error when working with saveUnknown is true and contains nested array of objects and when there's a null property.




### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [ ] I have updated the Dynamoose documentation (if required) given the changes I made
- [ ] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
