### PR TITLE
feat(schema.js): update_schema_timestamps

### DIFF
--- a/docs/api/schema.md
+++ b/docs/api/schema.md
@@ -361,6 +361,35 @@ var schema = new Schema({...}, {
   timestamps: true
 });
 ```
+You can specify to add only createdAt or updatedAt only, like in the examples below that add only createdAt field:
+```js
+var schema = new Schema({...}, {
+  throughput: 5,
+  timestamps: {
+    createdAt: true
+    updatedAt: false
+  }
+});
+```
+or also: 
+```js
+var schema = new Schema({...}, {
+  throughput: 5,
+  timestamps: {
+    createdAt: 'creationDate'
+    updatedAt: false
+  }
+});
+```
+or even: 
+```js
+var schema = new Schema({...}, {
+  throughput: 5,
+  timestamps: {
+    updatedAt: false
+  }
+});
+```
 
 You can specify the names that the fields will use, like in the following example:
 

--- a/dynamoose.d.ts
+++ b/dynamoose.d.ts
@@ -86,7 +86,7 @@ declare module "dynamoose" {
     throughput?: boolean | { read: number, write: number } | "ON_DEMAND";
     useNativeBooleans?: boolean;
     useDocumentTypes?: boolean;
-    timestamps?: boolean | { createdAt: string, updatedAt: string };
+    timestamps?: boolean | { createdAt?: string | boolean, updatedAt?: string|boolean };
     expires?: number | { ttl: number, attribute: string, returnExpiredItems: boolean };
     saveUnknown?: boolean;
 

--- a/lib/Schema.js
+++ b/lib/Schema.js
@@ -53,29 +53,36 @@ function Schema (obj, options) {
   if (this.options.timestamps) {
     let createdAt = null;
     let updatedAt = null;
+    const createdAtDefault = 'createdAt';
+    const updatedAtDefault = 'updatedAt';
 
     if (this.options.timestamps === true) {
-      createdAt = 'createdAt';
-      updatedAt = 'updatedAt';
+      createdAt = createdAtDefault;
+      updatedAt = updatedAtDefault;
     } else if (typeof this.options.timestamps === 'object') {
-      if (this.options.timestamps.createdAt && this.options.timestamps.updatedAt) {
+      if (typeof this.options.timestamps.createdAt !== 'undefined' || typeof this.options.timestamps.updatedAt !== 'undefined') {
         ({createdAt, updatedAt} = this.options.timestamps);
+        createdAt = typeof createdAt === 'undefined' ? true : createdAt;
+        updatedAt = typeof updatedAt === 'undefined' ? true : updatedAt;
       } else {
         throw new errors.SchemaError('Missing createdAt and updatedAt timestamps attribute. Maybe set timestamps: true?');
       }
     } else {
       throw new errors.SchemaError(`Invalid syntax for timestamp: ${this.options.timestamps}`);
     }
-
-    obj[createdAt] = obj[createdAt] || {};
-    obj[createdAt].type = Date;
-    obj[createdAt].default = Date.now;
-
-
-    obj[updatedAt] = obj[updatedAt] || {};
-    obj[updatedAt].type = Date;
-    obj[updatedAt].default = Date.now;
-    obj[updatedAt].set = function () { return Date.now(); };
+    createdAt = createdAt === true ? createdAtDefault : createdAt;
+    updatedAt = updatedAt === true ? updatedAtDefault : updatedAt;
+    if (createdAt) {
+      obj[createdAt] = obj[createdAt] || {};
+      obj[createdAt].type = Date;
+      obj[createdAt].default = Date.now;
+    }
+    if (updatedAt) {
+      obj[updatedAt] = obj[updatedAt] || {};
+      obj[updatedAt].type = Date;
+      obj[updatedAt].default = Date.now;
+      obj[updatedAt].set = function () { return Date.now(); };
+    }
     this.timestamps = {createdAt, updatedAt};
   }
 

--- a/test/Schema.js
+++ b/test/Schema.js
@@ -293,6 +293,116 @@ describe('Schema tests', function () {
 
     done();
   });
+  it('Schema with only createdAt timestamp options', (done) => {
+    const schema1 = new Schema({
+      'id': {
+        'type': Number,
+        'rangeKey': true
+      },
+      'name': {
+        'type': String,
+        'required': true
+      }
+    },
+    {
+      'throughput': {'read': 10, 'write': 2},
+      'timestamps': {
+        'updatedAt': false
+      }
+    });
+
+    const schema2 = new Schema({
+      'id': {
+        'type': Number,
+        'rangeKey': true
+      },
+      'name': {
+        'type': String,
+        'required': true
+      }
+    },
+    {
+      'throughput': {'read': 10, 'write': 2},
+      'timestamps': {'createdAt': 'createDate', 'updatedAt': false}
+    });
+
+    //
+    // Schema1 timestamps validation
+    //
+    should.exist(schema1.timestamps);
+    should.exist(schema1.timestamps.createdAt);
+    schema1.timestamps.createdAt.should.be.equal('createdAt');
+    should.not.exist(schema1.attributes.updatedAt);
+
+    schema1.attributes.createdAt.type.name.should.eql('date');
+    should.exist(schema1.attributes.createdAt.default);
+
+    //
+    // Schema2 timestamps validation
+    //
+    should.exist(schema2.timestamps);
+    should.exist(schema2.timestamps.createdAt);
+    schema2.timestamps.createdAt.should.be.equal('createDate');
+
+    schema2.attributes.createDate.type.name.should.eql('date');
+    should.exist(schema2.attributes.createDate.default);
+    done();
+  });
+  it('Schema with only updatedAt timestamp options', (done) => {
+    const schema1 = new Schema({
+      'id': {
+        'type': Number,
+        'rangeKey': true
+      },
+      'name': {
+        'type': String,
+        'required': true
+      }
+    },
+    {
+      'throughput': {'read': 10, 'write': 2},
+      'timestamps': {
+        'createdAt': false
+      }
+    });
+
+    const schema2 = new Schema({
+      'id': {
+        'type': Number,
+        'rangeKey': true
+      },
+      'name': {
+        'type': String,
+        'required': true
+      }
+    },
+    {
+      'throughput': {'read': 10, 'write': 2},
+      'timestamps': {'createdAt': false, 'updatedAt': 'updateDate'}
+    });
+
+    //
+    // Schema1 updatedAt timestamp validation
+    //
+    should.exist(schema1.timestamps);
+    should.exist(schema1.timestamps.updatedAt);
+    schema1.timestamps.updatedAt.should.be.equal('updatedAt');
+    should.not.exist(schema1.attributes.createdAt);
+
+    schema1.attributes.updatedAt.type.name.should.eql('date');
+    should.exist(schema1.attributes.updatedAt.default);
+
+    //
+    // Schema2 updatedAt timestamp validation
+    //
+    should.exist(schema2.timestamps);
+    should.exist(schema2.timestamps.updatedAt);
+    schema2.timestamps.updatedAt.should.be.equal('updateDate');
+
+    schema2.attributes.updateDate.type.name.should.eql('date');
+    should.exist(schema2.attributes.updateDate.default);
+    done();
+  });
 
 
   it('Schema with timestamps options that are rangeKey', () => {


### PR DESCRIPTION

<!-- THANK YOU for your contribution to Dynamoose, we really appreciate you taking the time to improve this package, and look forward to reviewing your PR and getting the changes integrated into the package. Thanks again!! -->


### Summary:
The model/schema doesn't allow timestamps without adding both fields createdAt and updatedAt together , in case someone want to use just createdAt or updatedAt for example this is not possible with the timestamps option as true




<!-- Please remove the `Code sample` section below if it doesn't apply to this PR -->
### Code sample:
#### Schema
You can specify to add only createdAt or updatedAt only, like in the examples below that add only createdAt field:
```js
var schema = new Schema({...}, {
  throughput: 5,
  timestamps: {
    createdAt: true
    updatedAt: false
  }
});
```
or also: 
```js
var schema = new Schema({...}, {
  throughput: 5,
  timestamps: {
    createdAt: 'creationDate'
    updatedAt: false
  }
});
```
or even: 
```js
var schema = new Schema({...}, {
  throughput: 5,
  timestamps: {
    updatedAt: false
  }
});
```



<!-- Please remove the `GitHub linked issue` section below if there is no GitHub linked issue -->
### GitHub linked issue:
<!-- If this PR closes the issue please add `Closes` without the back ticks before the # sign below -->
Closes #683 


<!-- Please remove the `Other information` section below if it doesn't apply to this PR -->
### Other information:


### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
