### PR TITLE
Add promise and lastKey docs

### DIFF
--- a/docs/api/query.md
+++ b/docs/api/query.md
@@ -22,7 +22,24 @@ Queries a table or index, sets [`query.limit`](#querylimitlimit) to `1`.
 
 ### query.exec(callback)
 
-Executes the query against the table or index.
+Executes the query against the table or index. If no callback is provided, this returns a promise.
+
+```js
+Dog.query('breed').eq('Beagle').exec(function (err, dogs) {
+  // Look at all the beagles
+});
+```
+
+```js
+async function getBeagles() {
+  try {
+    const beagles = await Dog.query('breed').eq('Beagle').exec()
+    // Find out something about beagles
+  } catch (err) {
+    // Handle error
+  }
+}
+```
 
 ### query.all([delay[, max]])
 

--- a/docs/api/query.md
+++ b/docs/api/query.md
@@ -133,6 +133,19 @@ Sort in ascending order (default).
 
 Start query at key. Use `lastKey` returned in query.exec() callback.
 
+**Note:** `lastKey` is returned and must be passed as an object in the AWS format with type annotations
+
+```js
+{
+  "myPartitionKey": {
+    "S": "id"
+  },
+  "myRangeKey": {
+    "N": 123
+  }
+}
+```
+
 ### query.attributes(attributes)
 
 Set the list of attributes to return.


### PR DESCRIPTION
### Summary:
Added documentation to query.exec() for how it can be used with promises and async/await. Also added notation on lastKey, indicating that it is returned as and is expected to be a DynamoDB style object.

### GitHub linked issue:
https://github.com/dynamoosejs/dynamoose/issues/114

### Is this ready to be merged into Dynamoose? (select 1):
- [x] Yes
- [ ] No


### Other:
- [x] I have searched through the GitHub pull requests to ensure this PR has not already been submitted
- [x] I have updated the Dynamoose documentation (if required) given the changes I made
- [x] I have added/updated the Dynamoose test cases (if required) given the changes I made
- [x] I agree that all changes made in this pull request may be distributed and are made available in accordance with the [Dynamoose license](https://github.com/dynamoosejs/dynamoose/blob/master/LICENSE.txt)
- [x] All of my commits and commit messages are detailed, explain what changes were made, and are easy to follow and understand
- [x] I have filled out all fields above
