### PR TITLE
Document.isDynamoObject Empty Map Bug

### DIFF
--- a/lib/Document.js
+++ b/lib/Document.js
@@ -30,7 +30,7 @@ function DocumentCarrier(model) {
 			const keys = Object.keys(value);
 			const key = keys[0];
 			const nestedResult = (typeof value[key] === "object" && !(value[key] instanceof Buffer) ? (Array.isArray(value[key]) ? value[key].every((value) => Document.isDynamoObject(value, true)) : Document.isDynamoObject(value[key])) : true);
-			return typeof value === "object" && keys.length === 1 && utils.dynamodb.attribute_types.includes(key) && (nestedResult || utils.attribute_types.find((a) => a.dynamodbType === key).isSet);
+			return typeof value === "object" && keys.length === 1 && utils.dynamodb.attribute_types.includes(key) && (nestedResult || Object.keys(value[key]).length === 0 || utils.attribute_types.find((a) => a.dynamodbType === key).isSet);
 		}
 
 		const keys = Object.keys(object);

--- a/test/Document.js
+++ b/test/Document.js
@@ -1124,6 +1124,14 @@ describe("Document", () => {
 			{
 				"input": {"id": {"N": "1"}, "friends": {"L": [{"S": "Tim"}, {"S": "Bob"}]}},
 				"output": true
+			},
+			{
+				"input": {"data": {"M": {}}},
+				"output": true
+			},
+			{
+				"input": {"data": {"L": []}},
+				"output": true
 			}
 		];
 


### PR DESCRIPTION
There is a bug where an object (ex. `{"data": {"M": {}}}`) with an empty map being passed into `Document.isDynamoObject` returns `false` instead of the expected `true` value. This PR fixes that bug.