### PR TITLE
Update transaction return values fix

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -88,14 +88,17 @@ class Model {
 			{"key": "get"},
 			{"key": "create", "dynamoKey": "Put"},
 			{"key": "delete"},
-			{"key": "update", "settingsIndex": 2},
+			{"key": "update", "settingsIndex": 2, "modifier": (response) => {
+				delete response.ReturnValues;
+				return response;
+			}},
 			{"key": "condition", "settingsIndex": -1, "dynamoKey": "ConditionCheck", "function": (key, options) => ({
 				...options,
 				"Key": convertObjectToKey.bind(this)(key),
 				"TableName": this.name
 			})}
 		].reduce((accumulator, currentValue) => {
-			const {key} = currentValue;
+			const {key, modifier} = currentValue;
 			const dynamoKey = currentValue.dynamoKey || utils.capitalize_first_letter(key);
 			const settingsIndex = currentValue.settingsIndex || 1;
 			const func = currentValue.function || this[key].bind(this);
@@ -109,7 +112,11 @@ class Model {
 				if (settingsIndex >= 0) {
 					args[settingsIndex] = utils.merge_objects({"return": "request"}, args[settingsIndex] || {});
 				}
-				return {[dynamoKey]: await func(...args)};
+				let result = await func(...args);
+				if (modifier) {
+					result = modifier(result);
+				}
+				return {[dynamoKey]: result};
 			};
 
 			return accumulator;

--- a/test/Model.js
+++ b/test/Model.js
@@ -2156,7 +2156,6 @@ describe("Model", () => {
 						"ExpressionAttributeValues": {
 							":v0": {"S": "Bob"}
 						},
-						"ReturnValues": "ALL_NEW",
 						"UpdateExpression": "SET #a0 = :v0",
 						"TableName": "User"
 					}


### PR DESCRIPTION
There was a bug with update transactions where `ReturnValues` wasn't allowed to be passed in. This PR removes that from update transactions.