### PR TITLE
Model.update Multiple Updates Race Condition

### DIFF
--- a/lib/Model.js
+++ b/lib/Model.js
@@ -292,7 +292,9 @@ Model.prototype.update = function(keyObj, updateObj, settings = {}, callback) {
 				key = "$SET";
 			}
 
-			await Promise.all(Object.keys(value).map(async (subKey) => {
+			const valueKeys = Object.keys(value);
+			for (let i = 0; i < valueKeys.length; i++) {
+				let subKey = valueKeys[i];
 				let subValue = value[subKey];
 
 				let updateType = updateTypes.find((a) => a.name === key);
@@ -331,7 +333,7 @@ Model.prototype.update = function(keyObj, updateObj, settings = {}, callback) {
 				accumulator.UpdateExpression[updateType.name.slice(1)].push(`${expressionKey}${operator}${expressionValue}`);
 
 				index++;
-			}));
+			}
 
 			return accumulator;
 		}, Promise.resolve((async () => {

--- a/test/Model.js
+++ b/test/Model.js
@@ -1307,6 +1307,34 @@ describe("Model", () => {
 					});
 				});
 
+				it("Should send correct params to updateItem with $SET update expression and multiple property updates", async () => {
+					updateItemFunction = () => Promise.resolve({});
+					await callType.func(User).bind(User)({"id": 1}, {"$SET": {"name": "Charlie", "age": 5}});
+					expect(updateItemParams).to.be.an("object");
+					expect(updateItemParams).to.eql({
+						"ExpressionAttributeNames": {
+							"#a0": "name",
+							"#a1": "age"
+						},
+						"ExpressionAttributeValues": {
+							":v0": {
+								"S": "Charlie"
+							},
+							":v1": {
+								"N": "5"
+							}
+						},
+						"UpdateExpression": "SET #a0 = :v0, #a1 = :v1",
+						"Key": {
+							"id": {
+								"N": "1"
+							}
+						},
+						"TableName": "User",
+						"ReturnValues": "ALL_NEW"
+					});
+				});
+
 				it("Should send correct params to updateItem with $SET update expression for list", async () => {
 					updateItemFunction = () => Promise.resolve({});
 					User = new dynamoose.Model("User", {"id": Number, "friends": {"type": Array, "schema": [String]}});


### PR DESCRIPTION
There was an issue where if passing in an object to update with update types (ex. `$SET`) and multiple updates inside of that one object type, there would be a race condition and the resulting request to DynamoDB would be corrupted and fail. This PR fixes that bug.