### PR TITLE
Expired object return undefined

### DIFF
--- a/lib/Document.js
+++ b/lib/Document.js
@@ -105,7 +105,7 @@ function DocumentCarrier(model) {
 	// This function will return an object that conforms to the schema (removing any properties that don't exist, using default values, etc.) & throws an error if there is a typemismatch.
 	Document.objectFromSchema = async function(object, settings = {"type": "toDynamo"}) {
 		if (settings.checkExpiredItem && model.options.expires && (model.options.expires.items || {}).returnExpired === false && object[model.options.expires.attribute] && (object[model.options.expires.attribute] * 1000) < Date.now()) {
-			return null;
+			return undefined;
 		}
 
 		const dynamooseUndefined = require("./index").undefined;

--- a/test/Document.js
+++ b/test/Document.js
@@ -1438,7 +1438,7 @@ describe("Document", () => {
 			{
 				"input": [{"id": 1, "ttl": 1}, {"type": "fromDynamo", "checkExpiredItem": true}],
 				"model": ["User", {"id": Number}, {"create": false, "waitForActive": false, "expires": {"ttl": 1000, "attribute": "ttl", "items": {"returnExpired": false}}}],
-				"output": null
+				"output": undefined
 			},
 			{
 				"input": [{"id": 1, "items": ["test"]}, {"type": "toDynamo", "saveUnknown": true}],

--- a/test/Model.js
+++ b/test/Model.js
@@ -700,11 +700,11 @@ describe("Model", () => {
 					});
 				});
 
-				it("Should return null for expired object", async () => {
+				it("Should return undefined for expired object", async () => {
 					User = new dynamoose.Model("User", {"id": Number}, {"expires": {"ttl": 1000, "items": {"returnExpired": false}}});
 					getItemFunction = () => Promise.resolve({"Item": {"id": {"N": "1"}, "ttl": {"N": "1"}}});
 					const user = await callType.func(User).bind(User)(1);
-					expect(user).to.eql(null);
+					expect(user).to.eql(undefined);
 				});
 
 				it("Should return expired object if returnExpired is not set", async () => {

--- a/test/Query.js
+++ b/test/Query.js
@@ -91,7 +91,7 @@ describe("Query", () => {
 					expect((await callType.func(Model.query("name").eq("Charlie").exec).bind(Model.query("name").eq("Charlie"))()).map((item) => ({...item}))).to.eql([{"id": 1, "name": "Charlie"}]);
 				});
 
-				it("Should return null for expired object", async () => {
+				it("Should return undefined for expired object", async () => {
 					queryPromiseResolver = () => ({"Items": [{"id": {"N": "1"}, "name": {"S": "Charlie"}, "ttl": {"N": "1"}}]});
 					Model = new dynamoose.Model("Cat", {"id": Number, "name": {"type": String, "index": {"global": true}}}, {"expires": {"ttl": 1000, "items": {"returnExpired": false}}});
 					expect((await callType.func(Model.query("name").eq("Charlie").exec).bind(Model.query("name").eq("Charlie"))()).map((item) => ({...item}))).to.eql([]);

--- a/test/Scan.js
+++ b/test/Scan.js
@@ -83,7 +83,7 @@ describe("Scan", () => {
 					expect((await callType.func(Model.scan().exec).bind(Model.scan())()).map((item) => ({...item}))).to.eql([{"id": 1, "name": "Charlie"}]);
 				});
 
-				it("Should return null for expired object", async () => {
+				it("Should return undefined for expired object", async () => {
 					scanPromiseResolver = () => ({"Items": [{"id": {"N": "1"}, "ttl": {"N": "1"}}]});
 					Model = new dynamoose.Model("Cat", {"id": Number}, {"expires": {"ttl": 1000, "items": {"returnExpired": false}}});
 					expect((await callType.func(Model.scan().exec).bind(Model.scan())()).map((item) => ({...item}))).to.eql([]);


### PR DESCRIPTION
Instead of expired objects returning `null` if `expires.items.returnExpired` is set to `true` it will now return `undefined` to be better aligned with Dynamoose v1.