### PR TITLE
Unnecessary attributes in key

### DIFF
--- a/docs/api/Model.md
+++ b/docs/api/Model.md
@@ -196,6 +196,27 @@ User.get({"id": 1, "name": "Tim"}, (error, myUser) => {
 });
 ```
 
+```js
+const User = new dynamoose.Model("User", {"id": Number, "name": String});
+
+try {
+	const myUser = await User.get({"id": 1});
+	console.log(myUser);
+} catch (error) {
+	console.error(error);
+}
+
+// OR
+
+User.get({"id": 1}, (error, myUser) => {
+	if (error) {
+		console.error(error);
+	} else {
+		console.log(myUser);
+	}
+});
+```
+
 ## Model.create(document, [settings], [callback])
 
 This function lets you create a new document for a given model. This function is almost identical to creating a new document and calling `document.save`, with one key difference, this function will default to setting `overwrite` to false.
@@ -349,6 +370,27 @@ try {
 // OR
 
 User.get({"id": 1, "name": "Tim"}, (error) => {
+	if (error) {
+		console.error(error);
+	} else {
+		console.log("Successfully deleted item");
+	}
+});
+```
+
+```js
+const User = new dynamoose.Model("User", {"id": Number, "name": String});
+
+try {
+	await User.get({"id": 1});
+	console.log("Successfully deleted item");
+} catch (error) {
+	console.error(error);
+}
+
+// OR
+
+User.get({"id": 1}, (error) => {
 	if (error) {
 		console.error(error);
 	} else {

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -210,9 +210,23 @@ async function updateTable(model) {
 }
 
 function convertObjectToKey(key) {
-	return this.Document.toDynamo(typeof key === "object" ? key : {
-		[this.schema.getHashKey()]: key
-	});
+	let keyObject;
+	const hashKey = this.schema.getHashKey();
+	if (typeof key === "object") {
+		const rangeKey = this.schema.getRangeKey();
+		keyObject = {
+			[hashKey]: key[hashKey]
+		};
+		if (rangeKey && key[rangeKey]) {
+			keyObject[rangeKey] = key[rangeKey];
+		}
+	} else {
+		keyObject = {
+			[hashKey]: key
+		};
+	}
+
+	return this.Document.toDynamo(keyObject);
 }
 
 

--- a/test/Model.js
+++ b/test/Model.js
@@ -661,6 +661,21 @@ describe("Model", () => {
 
 				it("Should send correct params to getItem if we pass in an object", async () => {
 					getItemFunction = () => Promise.resolve({"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}}});
+					await callType.func(User).bind(User)({"id": 1});
+					expect(getItemParams).to.be.an("object");
+					expect(getItemParams).to.eql({
+						"Key": {
+							"id": {
+								"N": "1"
+							}
+						},
+						"TableName": "User"
+					});
+				});
+
+				it("Should send correct params to getItem if we pass in an object with range key", async () => {
+					getItemFunction = () => Promise.resolve({"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}}});
+					User = new dynamoose.Model("User", {"id": Number, "name": {"type": String, "rangeKey": true}});
 					await callType.func(User).bind(User)({"id": 1, "name": "Charlie"});
 					expect(getItemParams).to.be.an("object");
 					expect(getItemParams).to.eql({
@@ -670,6 +685,20 @@ describe("Model", () => {
 							},
 							"name": {
 								"S": "Charlie"
+							}
+						},
+						"TableName": "User"
+					});
+				});
+
+				it("Should send correct params to getItem if we pass in an entire object with unnecessary attributes", async () => {
+					getItemFunction = () => Promise.resolve({"Item": {"id": {"N": "1"}, "name": {"S": "Charlie"}}});
+					await callType.func(User).bind(User)({"id": 1, "name": "Charlie"});
+					expect(getItemParams).to.be.an("object");
+					expect(getItemParams).to.eql({
+						"Key": {
+							"id": {
+								"N": "1"
 							}
 						},
 						"TableName": "User"
@@ -2016,6 +2045,21 @@ describe("Model", () => {
 
 				it("Should send correct params to deleteItem if we pass in an object", async () => {
 					deleteItemFunction = () => Promise.resolve();
+					await callType.func(User).bind(User)({"id": 1});
+					expect(deleteItemParams).to.be.an("object");
+					expect(deleteItemParams).to.eql({
+						"Key": {
+							"id": {
+								"N": "1"
+							}
+						},
+						"TableName": "User"
+					});
+				});
+
+				it("Should send correct params to deleteItem if we pass in an object with range key", async () => {
+					deleteItemFunction = () => Promise.resolve();
+					User = new dynamoose.Model("User", {"id": Number, "name": {"type": String, "rangeKey": true}});
 					await callType.func(User).bind(User)({"id": 1, "name": "Charlie"});
 					expect(deleteItemParams).to.be.an("object");
 					expect(deleteItemParams).to.eql({
@@ -2030,6 +2074,21 @@ describe("Model", () => {
 						"TableName": "User"
 					});
 				});
+
+				it("Should send correct params to deleteItem if we pass in an entire object with unnecessary attributes", async () => {
+					deleteItemFunction = () => Promise.resolve();
+					await callType.func(User).bind(User)({"id": 1, "name": "Charlie"});
+					expect(deleteItemParams).to.be.an("object");
+					expect(deleteItemParams).to.eql({
+						"Key": {
+							"id": {
+								"N": "1"
+							}
+						},
+						"TableName": "User"
+					});
+				});
+
 
 				it("Should return request if return request setting is set", async () => {
 					const result = await callType.func(User).bind(User)(1, {"return": "request"});


### PR DESCRIPTION
This PR fixes a glitch where passing an entire document into `Model.get` or `Model.delete` would fail due to extra attributes in the key.