### PR TITLE
TTL Update Fixes

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -6,7 +6,7 @@ The following is a chart of IAM permissions you need in order to run Dynamoose f
 
 | Dynamoose Action | IAM Permission | Notes |
 |------------------|----------------|-------|
-| new Model() | `createTable`, `describeTable`, `updateTable`, `updateTimeToLive` | `createTable` is only used if `create` is set to true. `describeTable` is only used if `waitForActive` OR `create` is set to true. `updateTable` is only used if `update` is set to true. `updateTimeToLive` is only used if `create` or `update` is set to true and there is an `expires` setting on the model. |
+| new Model() | `createTable`, `describeTable`, `updateTable`, `updateTimeToLive`, `describeTimeToLive` | `createTable` is only used if `create` is set to true. `describeTable` is only used if `waitForActive` OR `create` is set to true. `updateTable` is only used if `update` is set to true. `updateTimeToLive` & `describeTimeToLive` is only used if `create` or `update` is set to true and there is an `expires` setting on the model. |
 | Model.get | `getItem` |  |
 | Model.scan | `scan` | This permission is only required on `scan.exec` |
 | Model.query | `query` | This permission is only required on `query.exec` |
@@ -15,6 +15,7 @@ The following is a chart of IAM permissions you need in order to run Dynamoose f
 | Model.delete | `deleteItem` |  |
 | document.save | `putItem` |  |
 | document.delete | `deleteItem` |  |
+| dynamoose.transaction | `transactGetItems`, `transactWriteItems` |  |
 
 ## Why is it recommended to set `create` & `waitForActive` model options to false for production environments?
 

--- a/lib/Model.js
+++ b/lib/Model.js
@@ -144,13 +144,42 @@ async function createTableRequest(model) {
 	};
 }
 function updateTimeToLive(model) {
-	return aws.ddb().updateTimeToLive({
-		"TableName": model.name,
-		"TimeToLiveSpecification": {
-			"AttributeName": model.options.expires.attribute,
-			"Enabled": true
+	return {
+		"promise": async () => {
+			let ttlDetails;
+
+			async function updateDetails() {
+				ttlDetails = await aws.ddb().describeTimeToLive({
+					"TableName": model.name
+				}).promise();
+			}
+			await updateDetails();
+
+			function updateTTL() {
+				return aws.ddb().updateTimeToLive({
+					"TableName": model.name,
+					"TimeToLiveSpecification": {
+						"AttributeName": model.options.expires.attribute,
+						"Enabled": true
+					}
+				});
+			}
+
+			switch (ttlDetails.TimeToLiveDescription.TimeToLiveStatus) {
+			case "DISABLING":
+				while (ttlDetails.TimeToLiveDescription.TimeToLiveStatus === "DISABLING") {
+					await utils.timeout(1000);
+					await updateDetails();
+				}
+				// fallthrough
+			case "DISABLED":
+				await updateTTL();
+				break;
+			default:
+				break;
+			}
 		}
-	});
+	};
 }
 function waitForActive(model) {
 	return () => new Promise((resolve, reject) => {


### PR DESCRIPTION
There was a bug where if we tried to enable TTL when it was already enabled, it would throw an error. This PR fixes that by checking for existing TTL details before attempting to enable it.